### PR TITLE
Update aws:collect-azs task to read regions from DB

### DIFF
--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -35,6 +35,8 @@ func NewTaskCommand() *cli.Command {
 					switch ctx.Args().First() {
 					case tasks.AWS_COLLECT_REGIONS_TYPE:
 						task = tasks.NewAwsCollectRegionsTask()
+					case tasks.AWS_COLLECT_AZS_TYPE:
+						task = tasks.NewCollectAzsTask()
 					default:
 						slog.Error("unknown task type", "type", ctx.Args().First())
 					}

--- a/pkg/aws/tasks/regions.go
+++ b/pkg/aws/tasks/regions.go
@@ -51,7 +51,7 @@ func collectRegions(ctx context.Context) error {
 		regions = append(regions, modelRegion)
 
 		// Create asynq task for collecting availability zones
-		azsTask := NewAwsCollectAzsTask(*region.RegionName)
+		azsTask := NewCollectAzsRegionTask(*region.RegionName)
 		info, err := clients.Client.Enqueue(azsTask)
 		if err != nil {
 			slog.Error("could not enqueue task", "type", azsTask.Type(), "err", err)

--- a/pkg/aws/tasks/tasks.go
+++ b/pkg/aws/tasks/tasks.go
@@ -36,7 +36,8 @@ func HandleSampleTask(ctx context.Context, t *asynq.Task) error {
 func init() {
 	// Task handlers
 	registry.TaskRegistry.MustRegister(AWS_COLLECT_REGIONS_TYPE, asynq.HandlerFunc(HandleAwsCollectRegionsTask))
-	registry.TaskRegistry.MustRegister(AWS_COLLECT_AZS_TYPE, asynq.HandlerFunc(HandleAwsCollectAzsTask))
+	registry.TaskRegistry.MustRegister(AWS_COLLECT_AZS_TYPE, asynq.HandlerFunc(HandleCollectAzsTask))
+	registry.TaskRegistry.MustRegister(AWS_COLLECT_AZS_REGION_TYPE, asynq.HandlerFunc(HandleCollectAzsRegionTask))
 
 	// Periodic tasks
 	sampleTask := NewSampleTask()


### PR DESCRIPTION
This PR brings following updates to the collect-azs tasks:

  * Add aws:collect-azs-region task to fetch availability zones for a given region
  * Update aws:collect-azs task to fetch regions from the database
  * Enable aws:collect-azs task in inventory cli


```feature developer
Support aws:collect-azs-region and aws:collect-azs tasks
```
