### PR TITLE
proj: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Create PRs for dependency updates
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ":seedling:"
+  # Create PRs for golang version updates
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ":seedling:"


### PR DESCRIPTION
This PR brings a dependabot configuration to the project to handle the dependencies updates.
It runs on a weekly schedule and utilizes gomod and docker package ecosystems.

```feature developer
Project dependencies are now handled with dependabot.
```
