### PR TITLE
feat: support gke-gcloud-auth-plugin authentication

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,7 @@ services:
       AWS_CONFIG_FILE: /home/nonroot/.aws/config
       AWS_SHARED_CREDENTIALS_FILE: /home/nonroot/.aws/credentials
       AWS_PROFILE: default
+      CLOUDSDK_CONFIG: /home/nonroot/.config/gcloud
       INVENTORY_CONFIG: /home/nonroot/config.yaml
       REDIS_ENDPOINT: *redis-endpoint
       DATABASE_URI: *postgres-uri
@@ -68,6 +69,7 @@ services:
       - ~/.kube/cache:/home/nonroot/.kube/cache
       - ${KUBECONFIG}:/home/nonroot/.kube/config
       - ./examples/config.yaml:/home/nonroot/config.yaml
+      - ~/.config/gcloud:/home/nonroot/.config/gcloud
 
   scheduler:
     build:


### PR DESCRIPTION
This PR adds gcloud and gke-gcloud-auth-plugin to the worker service enabling kubeconfig contexts where the users are authenticated with the corresponding plugins.

```feature user
The worker service now supports kube contexts that use gke-gcloud-auth-plugin for authentication.
```
