### PR TITLE
chore: update dependabot configuration to skip updating gardener packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: ":seedling:"
+    # Skip gardaner packages. These shall be updated manually.
+    ignore:
+      - dependency-name: github.com/gardener/*
+        versions:
+          - "*"
   # Create PRs for golang version updates
   - package-ecosystem: docker
     directory: /


### PR DESCRIPTION
This PR updates dependabot configuration to skip updates for the gardener dependencies.
The reationale is from one side the frequent bi-weekly update of gardener and from the other side the stable nature of the dependencies.
Gardener updates do not bring updates to the particular dependencies of versioned clientsets for the gardener resources.

```feature developer
Gardener dependencies shall be managed manually outside the dependabot plugin.
```
