### PR TITLE
utils/strings: Tests for StringFromPointer

### DIFF
--- a/pkg/utils/strings/strings_test.go
+++ b/pkg/utils/strings/strings_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package strings
+
+import (
+	"testing"
+)
+
+func TestStringFromPointer(t *testing.T) {
+	emptyString := ""
+	nonEmptyString := "abc"
+	flagtests := []struct {
+		in  *string
+		out string
+	}{
+		{nil, ""},
+		{&emptyString, ""},
+		{&nonEmptyString, nonEmptyString},
+	}
+
+	for _, tt := range flagtests {
+		out := StringFromPointer(tt.in)
+
+		if tt.out != out {
+			t.Fatalf(`StringFromPointer(%v) == %q, expected %q.`, tt.in, out, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To add initial tests and validate the workflow/tooling around go testing.

**Release note**:
<!--  Write your release note:
-->
NONE