### PR TITLE
deployment/kustomize/worker: add `worker` service account

### DIFF
--- a/deployment/kustomize/worker/deployment.yaml
+++ b/deployment/kustomize/worker/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: worker
     spec:
+      serviceAccountName: worker
       initContainers:
         - name: init-db
           image: europe-docker.pkg.dev/gardener-project/releases/gardener/inventory:latest

--- a/deployment/kustomize/worker/kustomization.yaml
+++ b/deployment/kustomize/worker/kustomization.yaml
@@ -10,4 +10,5 @@ generatorOptions:
   disableNameSuffixHash: true
 
 resources:
+  - serviceaccount.yaml
   - deployment.yaml

--- a/deployment/kustomize/worker/serviceaccount.yaml
+++ b/deployment/kustomize/worker/serviceaccount.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: worker
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: inventory
+    app.kubernetes.io/managed-by: kustomize
+  name: worker


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `worker` service account to the `worker` deployment.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
