### PR TITLE
docker-compose: mount prometheus data dir locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ go.work.sum
 # Local Docker volumes
 dev/local/postgres
 dev/local/redis
+dev/local/prometheus
 
 # direnv
 .envrc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,6 +128,7 @@ services:
         condition: service_started
     volumes:
       - ./extra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./dev/local/prometheus:/prometheus
 
   pgadmin:
     image: dpage/pgadmin4:8.8


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR mounts mounts the Prometheus data dir locally when starting up the local setup using Docker Compose.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
