### PR TITLE
Link CloudProfileAWSImage to CloudProfile

### DIFF
--- a/internal/pkg/migrations/20240812061412_add_link_table_aws_image_to_cloud_profile.tx.down.sql
+++ b/internal/pkg/migrations/20240812061412_add_link_table_aws_image_to_cloud_profile.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "l_g_aws_image_to_cloud_profile";

--- a/internal/pkg/migrations/20240812061412_add_link_table_aws_image_to_cloud_profile.tx.up.sql
+++ b/internal/pkg/migrations/20240812061412_add_link_table_aws_image_to_cloud_profile.tx.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "l_g_aws_image_to_cloud_profile" (
+    "aws_image_id" bigint NOT NULL,
+    "cloud_profile_id" bigint NOT NULL,
+
+    "id" bigserial NOT NULL,
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("id"),
+    FOREIGN KEY ("aws_image_id") REFERENCES "g_cloud_profile_aws_image" ("id") ON DELETE CASCADE,
+    FOREIGN KEY ("cloud_profile_id") REFERENCES "g_cloud_profile" ("id") ON DELETE CASCADE,
+    CONSTRAINT "l_g_aws_image_to_cloud_profile_key" UNIQUE ("aws_image_id", "cloud_profile_id")
+);

--- a/pkg/gardener/models/models.go
+++ b/pkg/gardener/models/models.go
@@ -130,6 +130,15 @@ type CloudProfileAWSImage struct {
 	CloudProfile     *CloudProfile `bun:"rel:has-one,join:cloud_profile_name=name"`
 }
 
+// AWSImageToCloudProfile represents a link table connecting the CloudProfileAWSImage with CloudProfile.
+type AWSImageToCloudProfile struct {
+	bun.BaseModel `bun:"table:l_g_aws_image_to_cloud_profile"`
+	coremodels.Model
+
+	AWSImageID     uint64 `bun:"aws_image_id,notnull,unique:l_g_aws_image_to_cloud_profile_key"`
+	CloudProfileID uint64 `bun:"cloud_profile_id,notnull,unique:l_g_aws_image_to_cloud_profile_key"`
+}
+
 func init() {
 	// Register the models with the default registry
 	registry.ModelRegistry.MustRegister("g:model:project", &Project{})
@@ -144,4 +153,5 @@ func init() {
 	registry.ModelRegistry.MustRegister("g:model:link_shoot_to_project", &ShootToProject{})
 	registry.ModelRegistry.MustRegister("g:model:link_shoot_to_seed", &ShootToSeed{})
 	registry.ModelRegistry.MustRegister("g:model:link_machine_to_shoot", &MachineToShoot{})
+	registry.ModelRegistry.MustRegister("g:model:link_aws_image_to_cloud_profile", &AWSImageToCloudProfile{})
 }

--- a/pkg/gardener/tasks/tasks.go
+++ b/pkg/gardener/tasks/tasks.go
@@ -47,6 +47,7 @@ func HandleLinkAllTask(ctx context.Context, r *asynq.Task) error {
 		LinkShootWithProject,
 		LinkShootWithSeed,
 		LinkMachineWithShoot,
+		LinkAWSImageWithCloudProfile,
 	}
 
 	return utils.LinkObjects(ctx, db.DB, linkFns)


### PR DESCRIPTION
Creates a link table between CloudProfileAWSImage and CloudProfile. 
Creates a task for populating the table, which is executed by the link-all gardener task.

```feature user
Link CloudProfileAWSImage and CloudProfile Gardener resources.
```
