### PR TITLE
Fix g_cloud_profile_aws_image composite key to include cloud profile name

### DIFF
--- a/internal/pkg/migrations/20240812143448_add_cloud_profile_name_to_composite_key_gardener_cloud_profile_aws_image.tx.down.sql
+++ b/internal/pkg/migrations/20240812143448_add_cloud_profile_name_to_composite_key_gardener_cloud_profile_aws_image.tx.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "g_cloud_profile_aws_image" DROP CONSTRAINT "g_cloud_profile_aws_image_key";
+ALTER TABLE "g_cloud_profile_aws_image" ADD CONSTRAINT "g_cloud_profile_aws_image_key" UNIQUE ("name", "version", "region_name", "ami")

--- a/internal/pkg/migrations/20240812143448_add_cloud_profile_name_to_composite_key_gardener_cloud_profile_aws_image.tx.up.sql
+++ b/internal/pkg/migrations/20240812143448_add_cloud_profile_name_to_composite_key_gardener_cloud_profile_aws_image.tx.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "g_cloud_profile_aws_image" DROP CONSTRAINT "g_cloud_profile_aws_image_key";
+ALTER TABLE "g_cloud_profile_aws_image" ADD CONSTRAINT "g_cloud_profile_aws_image_key" UNIQUE ("name", "version", "region_name", "ami", "cloud_profile_name")

--- a/pkg/gardener/models/models.go
+++ b/pkg/gardener/models/models.go
@@ -126,7 +126,7 @@ type CloudProfileAWSImage struct {
 	RegionName       string        `bun:"region_name,notnull,unique:g_cloud_profile_aws_image_key"`
 	AMI              string        `bun:"ami,notnull,unique:g_cloud_profile_aws_image_key"`
 	Architecture     string        `bun:"architecture,notnull"`
-	CloudProfileName string        `bun:"cloud_profile_name,notnull"`
+	CloudProfileName string        `bun:"cloud_profile_name,notnull,unique:g_cloud_profile_aws_image_key"`
 	CloudProfile     *CloudProfile `bun:"rel:has-one,join:cloud_profile_name=name"`
 }
 

--- a/pkg/gardener/tasks/awsmachineimages.go
+++ b/pkg/gardener/tasks/awsmachineimages.go
@@ -93,7 +93,7 @@ func collectAWSMachineImages(ctx context.Context, p CollectMachineImagesPayload)
 
 	out, err := db.DB.NewInsert().
 		Model(&modelImages).
-		On("CONFLICT (name, ami, version, region_name) DO UPDATE").
+		On("CONFLICT (name, ami, version, region_name, cloud_profile_name) DO UPDATE").
 		Set("architecture = EXCLUDED.architecture").
 		Set("updated_at = EXCLUDED.updated_at").
 		Returning("id").


### PR DESCRIPTION
Currently, if two CloudProfiles have the same AMI, the composite key constraint overwrites the same record. To fix this, I included the cloud_profile_name field to the composite key of the g_cloud_profile_aws_image table.

**Special notes for your reviewer**:
The DOWN migration file might break future rollbacks, since the current (old) composite key will be compromised.
Me and @dnaeon had a discussion some time ago that this is fare for now, since we don't have a stable schema yet.

```feature user
Fix g_cloud_profile_aws_image composite key to include cloud profile name
```
