### PR TITLE
gardener/tasks: configure page size when fetching resources

### DIFF
--- a/pkg/gardener/constants/constants.go
+++ b/pkg/gardener/constants/constants.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package constants
+
+const (
+	// PageSize represents the max number of items to fetch during a
+	// paginated call.
+	PageSize = 100
+)

--- a/pkg/gardener/tasks/projects.go
+++ b/pkg/gardener/tasks/projects.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gardener/inventory/pkg/clients/db"
 	gardenerclient "github.com/gardener/inventory/pkg/clients/gardener"
+	"github.com/gardener/inventory/pkg/gardener/constants"
 	"github.com/gardener/inventory/pkg/gardener/models"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 	stringutils "github.com/gardener/inventory/pkg/utils/strings"
@@ -44,11 +45,13 @@ func HandleCollectProjectsTask(ctx context.Context, t *asynq.Task) error {
 	logger := asynqutils.GetLogger(ctx)
 	logger.Info("collecting Gardener projects")
 	projects := make([]models.Project, 0)
-	err = pager.New(
+	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1beta1().Projects().List(ctx, opts)
 		}),
-	).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	)
+	opts := metav1.ListOptions{Limit: constants.PageSize}
+	err = p.EachListItem(ctx, opts, func(obj runtime.Object) error {
 		p, ok := obj.(*v1beta1.Project)
 		if !ok {
 			return fmt.Errorf("unexpected object type: %T", obj)

--- a/pkg/gardener/tasks/seeds.go
+++ b/pkg/gardener/tasks/seeds.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gardener/inventory/pkg/clients/db"
 	gardenerclient "github.com/gardener/inventory/pkg/clients/gardener"
+	"github.com/gardener/inventory/pkg/gardener/constants"
 	"github.com/gardener/inventory/pkg/gardener/models"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 	stringutils "github.com/gardener/inventory/pkg/utils/strings"
@@ -43,11 +44,13 @@ func HandleCollectSeedsTask(ctx context.Context, t *asynq.Task) error {
 	logger := asynqutils.GetLogger(ctx)
 	logger.Info("collecting Gardener seeds")
 	seeds := make([]models.Seed, 0)
-	err = pager.New(
+	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1beta1().Seeds().List(ctx, metav1.ListOptions{})
 		}),
-	).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	)
+	opts := metav1.ListOptions{Limit: constants.PageSize}
+	err = p.EachListItem(ctx, opts, func(obj runtime.Object) error {
 		s, ok := obj.(*v1beta1.Seed)
 		if !ok {
 			return fmt.Errorf("unexpected object type: %T", obj)

--- a/pkg/gardener/tasks/shoots.go
+++ b/pkg/gardener/tasks/shoots.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gardener/inventory/pkg/clients/db"
 	gardenerclient "github.com/gardener/inventory/pkg/clients/gardener"
+	"github.com/gardener/inventory/pkg/gardener/constants"
 	"github.com/gardener/inventory/pkg/gardener/models"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 	stringutils "github.com/gardener/inventory/pkg/utils/strings"
@@ -46,11 +47,13 @@ func HandleCollectShootsTask(ctx context.Context, t *asynq.Task) error {
 	logger := asynqutils.GetLogger(ctx)
 	logger.Info("collecting Gardener shoots")
 	shoots := make([]models.Shoot, 0)
-	err = pager.New(
+	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 			return client.CoreV1beta1().Shoots("").List(ctx, metav1.ListOptions{})
 		}),
-	).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+	)
+	opts := metav1.ListOptions{Limit: constants.PageSize}
+	err = p.EachListItem(ctx, opts, func(obj runtime.Object) error {
 		s, ok := obj.(*v1beta1.Shoot)
 		if !ok {
 			return fmt.Errorf("unexpected object type: %T", obj)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR configures a page size when fetching Gardener resources similar to the way we do it for `gcp` and `aws`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Configure page size when fetching Gardener resources
```
