### PR TITLE
clients/gardener: MCMClient needs a client to a seed, not a shoot

### DIFF
--- a/pkg/gardener/tasks/backupbuckets.go
+++ b/pkg/gardener/tasks/backupbuckets.go
@@ -46,7 +46,7 @@ func HandleCollectBackupBucketsTask(ctx context.Context, t *asynq.Task) error {
 	buckets := make([]models.BackupBucket, 0)
 	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return client.CoreV1beta1().BackupBuckets().List(ctx, metav1.ListOptions{})
+			return client.CoreV1beta1().BackupBuckets().List(ctx, opts)
 		}),
 	)
 	opts := metav1.ListOptions{Limit: constants.PageSize}

--- a/pkg/gardener/tasks/cloudprofiles.go
+++ b/pkg/gardener/tasks/cloudprofiles.go
@@ -72,7 +72,7 @@ func HandleCollectCloudProfilesTask(ctx context.Context, t *asynq.Task) error {
 	cloudProfiles := make([]models.CloudProfile, 0)
 	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return client.CoreV1beta1().CloudProfiles().List(ctx, metav1.ListOptions{})
+			return client.CoreV1beta1().CloudProfiles().List(ctx, opts)
 		}),
 	)
 	opts := metav1.ListOptions{Limit: constants.PageSize}

--- a/pkg/gardener/tasks/seeds.go
+++ b/pkg/gardener/tasks/seeds.go
@@ -46,7 +46,7 @@ func HandleCollectSeedsTask(ctx context.Context, t *asynq.Task) error {
 	seeds := make([]models.Seed, 0)
 	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return client.CoreV1beta1().Seeds().List(ctx, metav1.ListOptions{})
+			return client.CoreV1beta1().Seeds().List(ctx, opts)
 		}),
 	)
 	opts := metav1.ListOptions{Limit: constants.PageSize}

--- a/pkg/gardener/tasks/shoots.go
+++ b/pkg/gardener/tasks/shoots.go
@@ -49,7 +49,7 @@ func HandleCollectShootsTask(ctx context.Context, t *asynq.Task) error {
 	shoots := make([]models.Shoot, 0)
 	p := pager.New(
 		pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-			return client.CoreV1beta1().Shoots("").List(ctx, metav1.ListOptions{})
+			return client.CoreV1beta1().Shoots("").List(ctx, opts)
 		}),
 	)
 	opts := metav1.ListOptions{Limit: constants.PageSize}


### PR DESCRIPTION


The `MCMClient` creates Machine Controller Manager clients to seed clusters, and internally uses `createGardenConfig`, which tests whether the name of the seed actually exists, before requesting `viewerkubeconfig` sub-resource.

Since our managed seeds are actually shoots in the virtual garden cluster, this is a perfectly valid thing to do. However, technically this is incorrect, since we should be testing against the list of seeds, and not shoots.

On larger environments this creates a performance issue, where getting all the shoots at once may result in high memory usage.

This commit will now test whether a seed actually exists and issue a `viewerkubeconfig` sub-resource for a managed seed, which is still a shoot to gardener.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
None
```
