### PR TITLE
Fix for Azure VM image collection task

### DIFF
--- a/pkg/gardener/tasks/azuremachineimages.go
+++ b/pkg/gardener/tasks/azuremachineimages.go
@@ -81,6 +81,10 @@ func collectAzureMachineImages(ctx context.Context, payload CollectCPMachineImag
 		}
 	}
 
+	if len(items) == 0 {
+		return nil
+	}
+
 	out, err := db.DB.NewInsert().
 		Model(&items).
 		On("CONFLICT (name, architecture, version, cloud_profile_name) DO UPDATE").


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a check for the length of slice about to be inserted in DB, since the insertion fails for empty slices.
lease note is required, just write "NONE" within the block.