### PR TITLE
Fix GCP disk zone and region fields

### DIFF
--- a/pkg/gcp/tasks/disks.go
+++ b/pkg/gcp/tasks/disks.go
@@ -154,13 +154,14 @@ func collectDisks(ctx context.Context, payload CollectDisksPayload) error {
 			}
 			currentDiskAttachedInstances := i.GetUsers()
 
+			zone := utils.ResourceNameFromURL(i.GetZone())
 			for _, instanceURL := range currentDiskAttachedInstances {
 				attachedDisk := models.AttachedDisk{
 					InstanceName: utils.ResourceNameFromURL(instanceURL),
 					DiskName:     i.GetName(),
 					ProjectID:    payload.ProjectID,
-					Zone:         i.GetZone(),
-					Region:       utils.UnqualifyRegion(pair.Key),
+					Zone:         zone,
+					Region:       utils.RegionFromZone(zone),
 				}
 				attachedDisks = append(attachedDisks, attachedDisk)
 			}
@@ -168,8 +169,8 @@ func collectDisks(ctx context.Context, payload CollectDisksPayload) error {
 			disk := models.Disk{
 				Name:              i.GetName(),
 				ProjectID:         payload.ProjectID,
-				Zone:              i.GetZone(),
-				Region:            utils.UnqualifyRegion(pair.Key),
+				Zone:              zone,
+				Region:            utils.RegionFromZone(zone),
 				CreationTimestamp: i.GetCreationTimestamp(),
 			}
 


### PR DESCRIPTION
Zone wasn't normalized. Region was outright incorrect.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
GCP: fix disk zone and region collection
```
