### PR TITLE
Number of GKE Clusters Grafana panel

### DIFF
--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -65,7 +65,7 @@ azure:
       use_credentials:
         - foo
 
-    # Storage service API clients collect Storage Accounts and Blob containers 
+    # Storage service API clients collect Storage Accounts and Blob containers
     storage:
       use_credentials:
         - foo
@@ -106,6 +106,15 @@ gcp:
   # User-Agent to set for the API clients
   user_agent: gardener-inventory/0.1.0
 
+  # GCP Soil cluster settings. The soil cluster is a GKE cluster from which
+  # Inventory will collect data as well. In order to discover the GKE cluster
+  # control plane endpoint and CA root of trust make sure to enable the named
+  # credentials used by the soil cluster in the `gcp.services.gke' service as
+  # well.
+  soil_cluster:
+    cluster_name: dev-soil-gcp
+    use_credentials: foo
+
   # This section provides configuration specific to each GCP service and which
   # named credentials to be used when creating API clients for the respective
   # service. Inventory supports specifying multiple named credentials per
@@ -120,13 +129,20 @@ gcp:
     resource_manager:
       use_credentials:
         - foo
+
     # Compute API clients collect Instances, VPCs, Subnets, Regional & Global
     # Addresses, Disks and Forwarding Rules.
     compute:
       use_credentials:
         - foo
+
     # Storage API clients collect Buckets.
     storage:
+      use_credentials:
+        - foo
+
+    # Collects GKE clusters
+    gke:
       use_credentials:
         - foo
 
@@ -160,10 +176,6 @@ gcp:
       projects:
         - project-baz
         - project-qux
-
-  # Gardener specific GCP settings
-  soil_regional_host:
-  soil_regional_ca_path:
 
 # AWS specific configuration
 aws:
@@ -320,6 +332,12 @@ scheduler:
     - name: "gcp:task:collect-forwarding-rules"
       spec: "@every 1h"
       desc: "Collect GCP Forwarding Rules"
+    - name: "gcp:task:collect-disks"
+      spec: "@every 1h"
+      desc: "Collect GCP Disks"
+    - name: "gcp:task:collect-gke-clusters"
+      spec: "@every 1h"
+      desc: "Collect GKE Clusters"
     - name: "gcp:task:link-all"
       spec: "@every 30m"
       desc: "Link all GCP models"
@@ -352,6 +370,9 @@ scheduler:
     - name: "az:task:collect-blob-containers"
       spec: "@every 1h"
       desc: "Collect Azure Blob containers"
+    - name: "az:task:link-all"
+      spec: "@every 1h"
+      desc: "Link all Azure models"
 
     # The housekeeper takes care of cleaning up stale records
     - name: "common:task:housekeeper"
@@ -412,6 +433,12 @@ scheduler:
           - name: "gcp:model:bucket"
             duration: 24h
           - name: "gcp:model:forwarding_rule"
+            duration: 24h
+          - name: "gcp:model:disk"
+            duration: 24h
+          - name: "gcp:model:attached_disk"
+            duration: 24h
+          - name: "gcp:model:gke_cluster"
             duration: 24h
           # Azure
           - name: "az:model:subscription"

--- a/deployment/kustomize/grafana/config/files/dashboards/inventory/inventory-gcp.json
+++ b/deployment/kustomize/grafana/config/files/dashboards/inventory/inventory-gcp.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 10,
+  "id": 6,
   "links": [],
   "panels": [
     {
@@ -751,7 +751,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -835,7 +836,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -918,7 +920,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1002,7 +1005,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1086,7 +1090,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1170,7 +1175,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -1519,7 +1525,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -1590,6 +1597,91 @@
       ],
       "title": "Number of Forwarding Rules",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "ds_gardener_inventory"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(id) FROM gcp_gke_cluster\nWHERE project_id in ($gcp_project);",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Number of GKE Clusters",
+      "type": "stat"
     }
   ],
   "schemaVersion": 39,
@@ -1632,6 +1724,6 @@
   "timezone": "browser",
   "title": "Inventory: GCP",
   "uid": "bdw5ley9qnpq8b",
-  "version": 9,
+  "version": 2,
   "weekStart": ""
 }

--- a/extra/grafana/dashboards/inventory/inventory-gcp.json
+++ b/extra/grafana/dashboards/inventory/inventory-gcp.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 10,
+  "id": 6,
   "links": [],
   "panels": [
     {
@@ -751,7 +751,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -835,7 +836,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -918,7 +920,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1002,7 +1005,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1086,7 +1090,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1170,7 +1175,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -1519,7 +1525,8 @@
             "mode": "percentage",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -1590,6 +1597,91 @@
       ],
       "title": "Number of Forwarding Rules",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "ds_gardener_inventory"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT COUNT(id) FROM gcp_gke_cluster\nWHERE project_id in ($gcp_project);",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Number of GKE Clusters",
+      "type": "stat"
     }
   ],
   "schemaVersion": 39,
@@ -1632,6 +1724,6 @@
   "timezone": "browser",
   "title": "Inventory: GCP",
   "uid": "bdw5ley9qnpq8b",
-  "version": 9,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a Grafana stats panel for number of GKE clusters.
Also syncs the kustomize config.yaml file with the examples/config.yaml one.

```feature user
Add number of GKE Clusters to Grafana
```
