### PR TITLE
migrations: improve performance of `gcp_orphan_disk`

### DIFF
--- a/internal/pkg/migrations/20241129084124_fix_gcp_orphan_disk_view_performance.tx.down.sql
+++ b/internal/pkg/migrations/20241129084124_fix_gcp_orphan_disk_view_performance.tx.down.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE VIEW "gcp_orphan_disk" AS
+SELECT
+    d.id,
+    d.name,
+    d.project_id,
+    d.zone,
+    d.type,
+    d.region,
+    d.description,
+    d.is_regional,
+    d.creation_timestamp,
+    d.last_attach_timestamp,
+    d.last_detach_timestamp,
+    d.status,
+    d.size_gb,
+    d.k8s_cluster_name,
+    d.created_at,
+    d.updated_at,
+    gad.instance_name,
+    s.is_hibernated AS shoot_is_hibernated
+FROM gcp_disk AS d
+LEFT JOIN g_persistent_volume as gpv ON gpv.disk_ref LIKE concat('%', d.name)
+LEFT JOIN g_shoot AS s ON d.k8s_cluster_name = s.technical_id
+LEFT JOIN gcp_attached_disk AS gad ON gad.disk_name = d.name
+WHERE
+    gpv.id IS NULL
+    AND d.id NOT IN (SELECT id FROM gcp_boot_disk UNION SELECT id FROM gcp_data_disk);

--- a/internal/pkg/migrations/20241129084124_fix_gcp_orphan_disk_view_performance.tx.up.sql
+++ b/internal/pkg/migrations/20241129084124_fix_gcp_orphan_disk_view_performance.tx.up.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE VIEW "gcp_orphan_disk" AS
+SELECT
+    d.id,
+    d.name,
+    d.project_id,
+    d.zone,
+    d.type,
+    d.region,
+    d.description,
+    d.is_regional,
+    d.creation_timestamp,
+    d.last_attach_timestamp,
+    d.last_detach_timestamp,
+    d.status,
+    d.size_gb,
+    d.k8s_cluster_name,
+    d.created_at,
+    d.updated_at,
+    gad.instance_name,
+    s.is_hibernated AS shoot_is_hibernated
+FROM gcp_disk AS d
+LEFT JOIN g_persistent_volume as gpv ON d.name = gpv.name
+LEFT JOIN g_shoot AS s ON d.k8s_cluster_name = s.technical_id
+LEFT JOIN gcp_attached_disk AS gad ON gad.disk_name = d.name
+WHERE
+    gpv.id IS NULL
+    AND d.id NOT IN (SELECT id FROM gcp_boot_disk UNION SELECT id FROM gcp_data_disk);


### PR DESCRIPTION
On large enough environments with many PVs and GCP disks, before this commit.

```sql
> select count(*) from g_persistent_volume;
┌───────┐
│ count │
├───────┤
│ 26598 │
└───────┘
(1 row)

Time: 8.869 ms

> select count(*) from gcp_disk;
┌───────┐
│ count │
├───────┤
│  3731 │
└───────┘
(1 row)

Time: 3.857 ms
```

The existing view takes ~ 30 seconds to identify leaked disks.
```sql
> select count(*) from gcp_orphan_disk;
┌───────┐
│ count │
├───────┤
│   120 │
└───────┘
(1 row)

Time: 29767.375 ms (00:29.767)
```

With this PR.

```sql
> select count(*) from gcp_orphan_disk;
┌───────┐
│ count │
├───────┤
│   120 │
└───────┘
(1 row)

Time: 46.782 ms
```

**Which issue(s) this PR fixes**:

Fixes a performance issue with `gcp_orphan_disk` view.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Improve performance of `gcp_orphan_disk` view
```
