### PR TITLE
gardener/tasks: collect PV source for the rest of in-tree drivers

### DIFF
--- a/pkg/gardener/tasks/persistent_volumes.go
+++ b/pkg/gardener/tasks/persistent_volumes.go
@@ -158,18 +158,47 @@ func collectPersistentVolumes(ctx context.Context, payload CollectPersistentVolu
 
 		switch {
 		case source.CSI != nil:
-			sourceName = source.CSI.Driver
+			sourceName = fmt.Sprintf("csi:%s", source.CSI.Driver)
 			diskRef = source.CSI.VolumeHandle
 		case source.GCEPersistentDisk != nil:
-			sourceName = "gce-persistent-disk"
+			sourceName = "in-tree:gce-pd"
 			diskRef = source.GCEPersistentDisk.PDName
 		case source.AWSElasticBlockStore != nil:
-			sourceName = "aws-elastic-block-store"
+			sourceName = "in-tree:aws-ebs"
 			diskRef = source.AWSElasticBlockStore.VolumeID
+		case source.HostPath != nil:
+			sourceName = "in-tree:host-path"
+			diskRef = source.HostPath.Path
+		case source.Glusterfs != nil:
+			sourceName = "in-tree:glusterfs"
+			diskRef = source.Glusterfs.Path
+		case source.NFS != nil:
+			sourceName = "in-tree:nfs"
+			diskRef = fmt.Sprintf("%s:%s", source.NFS.Server, source.NFS.Path)
 		case source.AzureDisk != nil:
-			sourceName = "azure-disk"
+			sourceName = "in-tree:azure-disk"
 			diskRef = source.AzureDisk.DiskName
-			// TODO: Add the rest of the in-tree drivers
+		case source.AzureFile != nil:
+			sourceName = "in-tree:azure-file"
+			diskRef = source.AzureFile.ShareName
+		case source.Cinder != nil:
+			sourceName = "in-tree:cinder"
+			diskRef = source.Cinder.VolumeID
+		case source.VsphereVolume != nil:
+			sourceName = "in-tree:vsphere"
+			diskRef = source.VsphereVolume.VolumePath
+		case source.PhotonPersistentDisk != nil:
+			sourceName = "in-tree:photon-pd"
+			diskRef = source.PhotonPersistentDisk.PdID
+		case source.PortworxVolume != nil:
+			sourceName = "in-tree:portworx"
+			diskRef = source.PortworxVolume.VolumeID
+		case source.Local != nil:
+			sourceName = "in-tree:local"
+			diskRef = source.Local.Path
+		case source.StorageOS != nil:
+			sourceName = "in-tree:storageos"
+			diskRef = source.StorageOS.VolumeName
 		}
 
 		var volumeMode string


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for collecting persistent volume source for the remaining in-tree drivers.

Example from data collected in a test env.

```sql
inventory=# select distinct(provider) from g_persistent_volume order by provider;
┌─────────────────────────────────────┐
│              provider               │
├─────────────────────────────────────┤
│ csi:cinder.csi.openstack.org        │
│ csi:disk.csi.azure.com              │
│ csi:diskplugin.csi.alibabacloud.com │
│ csi:ebs.csi.aws.com                 │
│ csi:pd.csi.storage.gke.io           │
│ in-tree:aws-ebs                     │
│ in-tree:azure-disk                  │
│ in-tree:cinder                      │
│ in-tree:gce-pd                      │
└─────────────────────────────────────┘
(9 rows)

Time: 3.575 ms
```


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
g:task:collect-persistent-volumes supports additional in-tree drivers
```
