### PR TITLE
Explicitly close asynq.Inspector in `worker start` handler

### DIFF
--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -145,6 +145,8 @@ func NewWorkerCommand() *cli.Command {
 					client := newAsynqClient(conf)
 					defer client.Close()
 					server := newServer(conf)
+					inspector := newInspector(conf)
+					defer inspector.Close()
 
 					// Gardener client configs
 					slog.Info("configuring gardener clients")
@@ -172,7 +174,7 @@ func NewWorkerCommand() *cli.Command {
 
 					// Initialize async inspector, for queue related tasks
 					slog.Info("configuring asynq inspector")
-					asynqclient.SetInspector(newInspector(conf))
+					asynqclient.SetInspector(inspector)
 
 					if err := configureAWSClients(ctx.Context, conf); err != nil {
 						return err


### PR DESCRIPTION
**What this PR does / why we need it**:
I forgot to add asynq.Inspector.Close() in the `worker start` handler.
This PR adds the call.

```feature user
Close asynq.Inspector after tasks are done.
```
