### PR TITLE
g/tasks: add support for specifying payload for `g:task:collect-projects`

### DIFF
--- a/pkg/gardener/tasks/errors.go
+++ b/pkg/gardener/tasks/errors.go
@@ -6,6 +6,10 @@ package tasks
 
 import "errors"
 
+// ErrNoProjectName is an error, which is returned when an expected Project Name
+// was not specified as part of the task payload.
+var ErrNoProjectName = errors.New("no project name specified")
+
 // ErrNoSeedCluster is an error, which is returned when an expected Seed Cluster
 // was not specified.
 var ErrNoSeedCluster = errors.New("no seed cluster specified")


### PR DESCRIPTION
**What this PR does / why we need it**:

Clients can now pass payload to the `g:task:collect-projects` task to collect specific projects only.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
g:task:collect-projects supports specifying payload to collect from specific projects
```
