### PR TITLE
feat: add support for configuring priority queues on workers

### DIFF
--- a/cmd/inventory/scheduler.go
+++ b/cmd/inventory/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hibiken/asynq"
@@ -128,6 +129,7 @@ func NewSchedulerCommand() *cli.Command {
 						"TYPE",
 						"PREV",
 						"NEXT",
+						"OPTS",
 					}
 
 					table := newTableWriter(os.Stdout, headers)
@@ -137,12 +139,19 @@ func NewSchedulerCommand() *cli.Command {
 						if item.Prev.IsZero() {
 							prev = na
 						}
+
+						opts := make([]string, 0)
+						for _, opt := range item.Opts {
+							opts = append(opts, opt.String())
+						}
+
 						row := []string{
 							item.ID,
 							item.Spec,
 							item.Task.Type(),
 							prev,
 							fmt.Sprintf("In %s", nextIn.String()),
+							strings.Join(opts, ", "),
 						}
 						table.Append(row)
 					}

--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -296,6 +296,10 @@ func newScheduler(conf *config.Config) *asynq.Scheduler {
 		LogLevel:            logLevel,
 	}
 
+	if conf.Scheduler.DefaultQueue == "" {
+		conf.Scheduler.DefaultQueue = config.DefaultQueueName
+	}
+
 	scheduler := asynq.NewScheduler(redisClientOpt, opts)
 	return scheduler
 }

--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -213,19 +213,27 @@ func newInspector(conf *config.Config) *asynq.Inspector {
 // newServer creates a new [asynq.Server] from the given config.
 func newServer(conf *config.Config) *asynq.Server {
 	redisClientOpt := newRedisClientOpt(conf)
+	defaultQueues := map[string]int{
+		config.DefaultQueueName: 1,
+	}
 
-	// TODO: Logger, priority queues, etc.
 	logLevel := asynq.InfoLevel
 	if conf.Debug {
 		logLevel = asynq.DebugLevel
 	}
 
-	config := asynq.Config{
-		Concurrency:  conf.Worker.Concurrency,
-		LogLevel:     logLevel,
-		ErrorHandler: asynqutils.NewDefaultErrorHandler(),
+	queues := conf.Worker.Queues
+	if len(queues) == 0 {
+		queues = defaultQueues
 	}
 
+	config := asynq.Config{
+		Concurrency:    conf.Worker.Concurrency,
+		LogLevel:       logLevel,
+		ErrorHandler:   asynqutils.NewDefaultErrorHandler(),
+		Queues:         queues,
+		StrictPriority: conf.Worker.StrictPriority,
+	}
 	server := asynq.NewServer(redisClientOpt, config)
 
 	return server

--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -203,6 +203,10 @@ func NewWorkerCommand() *cli.Command {
 					}
 
 					slog.Info("worker concurrency", "level", conf.Worker.Concurrency)
+					for queue, priority := range conf.Worker.Queues {
+						slog.Info("queue configuration", "name", queue, "priority", priority)
+					}
+
 					return server.Run(mux)
 				},
 			},

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -250,7 +250,13 @@ aws:
         role_arn: arn:aws:iam::account:role/name
         role_session_name: gardener-inventory-worker
 
+# Scheduler configuration
 scheduler:
+  # The queue to submit tasks when no queue has been explicitely specified for a
+  # periodic job.
+  default_queue: default
+
+  # Periodic jobs enqueued by the scheduler
   jobs:
     # AWS tasks
     - name: "aws:task:collect-regions"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -19,12 +19,30 @@ logging:
 redis:
   endpoint: redis:6379
 
+# Database settings
 database:
   dsn: "postgresql://inventory:p4ssw0rd@postgres:5432/inventory?sslmode=disable"
   migration_dir: ./internal/pkg/migrations
 
+# Worker settings
 worker:
+  # Concurrency level
   concurrency: 100
+
+  # Priority queue configuration.
+  #
+  # Check the following documentation for more details about how priority queues
+  # work.
+  # See https://github.com/hibiken/asynq/wiki/Queue-Priority
+  queues:
+    default: 1
+
+  # Strict priority specifies whether queue priority is treated strictly.
+  #
+  # When set to true tasks from queues with higher priority are always processed
+  # first, and tasks from queues with lower priority are processed only after
+  # higher priority queues are empty.
+  strict_priority: false
 
 dashboard:
   address: ":8080"

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -57,6 +57,11 @@ const (
 	// GardenerAuthenticationMethodKubeconfig is the name of the method for
 	// `kubeconfig' authentication.
 	GardenerAuthenticationMethodKubeconfig = "kubeconfig"
+
+	// DefaultQueueName is the name of the queue which will be used by the
+	// client, scheduler and workers, when no queue has been specified
+	// explicitly.
+	DefaultQueueName = "default"
 )
 
 // ErrNoConfigVersion error is returned when the configuration does not specify
@@ -434,6 +439,11 @@ type WorkerConfig struct {
 
 // SchedulerConfig provides scheduler specific configuration settings.
 type SchedulerConfig struct {
+	// DefaultQueue specifies the queue name to which tasks will be
+	// submitted, if a periodic job does not specify a queue explicitly
+	DefaultQueue string `yaml:"default_queue"`
+
+	// Jobs represents the periodic jobs managed by the scheduler
 	Jobs []*PeriodicJob `yaml:"jobs"`
 }
 
@@ -451,6 +461,11 @@ type PeriodicJob struct {
 
 	// Payload is an optional payload to use when submitting the task.
 	Payload string `yaml:"payload"`
+
+	// Queue specifies the name of the queue to which the task will be
+	// submitted. If it is not specified, then the task will be submitted to
+	// the [DefaultQueueName] queue.
+	Queue string `yaml:"queue"`
 }
 
 // GardenerConfig represents the Gardener specific configuration.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -435,6 +435,20 @@ type DatabaseConfig struct {
 type WorkerConfig struct {
 	// Concurrency specifies the concurrency level for workers.
 	Concurrency int `yaml:"concurrency"`
+
+	// Queues specifies the priority queue configuration for the worker.
+	//
+	// See [1] for more details about how priority queues work.
+	//
+	// [1]: https://github.com/hibiken/asynq/wiki/Queue-Priority
+	Queues map[string]int `yaml:"queues"`
+
+	// StrictPriority specifies whether queue priority is treated strictly.
+	//
+	// When it is set to true tasks from queues with higher priority are
+	// always processed first, and tasks from queues with lower priority are
+	// processed only after higher priority queues are empty.
+	StrictPriority bool `yaml:"strict_priority"`
 }
 
 // SchedulerConfig provides scheduler specific configuration settings.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for configuring multiple priority queues for `workers`. 

Additionally, the periodic jobs managed by the `scheduler` may now optionally specify a queue to which the task will be enqueued.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Add support for priority queues in workers
- Add support for specifying queue for periodic tasks
```
