### PR TITLE
feat: collect gardener resources, only if datasource is activated

### DIFF
--- a/cmd/inventory/utils_aws.go
+++ b/cmd/inventory/utils_aws.go
@@ -351,6 +351,10 @@ func configureAWSClients(ctx context.Context, conf *config.Config) error {
 	}
 
 	slog.Info("configuring AWS clients")
+	if err := validateAWSConfig(conf); err != nil {
+		return err
+	}
+
 	configFuncs := map[string]func(ctx context.Context, conf *config.Config) error{
 		"ec2":   configureEC2Clientset,
 		"elb":   configureELBClientset,

--- a/cmd/inventory/utils_azure.go
+++ b/cmd/inventory/utils_azure.go
@@ -90,6 +90,10 @@ func configureAzureClients(ctx context.Context, conf *config.Config) error {
 	}
 
 	slog.Info("configuring Azure clients")
+	if err := validateAzureConfig(conf); err != nil {
+		return err
+	}
+
 	configFuncs := map[string]func(ctx context.Context, conf *config.Config) error{
 		"compute":          configureAzureComputeClientsets,
 		"resource_manager": configureAzureResourceManagerClientsets,

--- a/cmd/inventory/utils_gardener.go
+++ b/cmd/inventory/utils_gardener.go
@@ -111,6 +111,10 @@ func configureGardenerClient(_ context.Context, conf *config.Config) error {
 		"token_path", conf.Gardener.TokenPath,
 	)
 
+	if err := validateGardenerConfig(conf); err != nil {
+		return err
+	}
+
 	restConfig, err := getGardenerRestConfig(conf)
 	if err != nil {
 		return fmt.Errorf("gardener: %w", err)

--- a/cmd/inventory/utils_gardener.go
+++ b/cmd/inventory/utils_gardener.go
@@ -99,6 +99,11 @@ func getGardenerRestConfig(conf *config.Config) (*rest.Config, error) {
 // configureGardenerClient configures the API client for interfacing with the
 // Gardener APIs.
 func configureGardenerClient(_ context.Context, conf *config.Config) error {
+	if !conf.Gardener.IsEnabled {
+		slog.Warn("Gardener is not enabled, will not create API client")
+		return nil
+	}
+
 	slog.Info(
 		"configuring Gardener API client",
 		"authentication", conf.Gardener.Authentication,

--- a/cmd/inventory/utils_gcp.go
+++ b/cmd/inventory/utils_gcp.go
@@ -431,6 +431,10 @@ func configureGCPClients(ctx context.Context, conf *config.Config) error {
 	}
 
 	slog.Info("configuring GCP clients")
+	if err := validateGCPConfig(conf); err != nil {
+		return err
+	}
+
 	configFuncs := map[string]func(ctx context.Context, conf *config.Config) error{
 		"resource_manager": configureGCPResourceManagerClientsets,
 		"compute":          configureGCPComputeClientsets,

--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -136,10 +136,6 @@ func NewWorkerCommand() *cli.Command {
 					validatorFuncs := []func(c *config.Config) error{
 						validateWorkerConfig,
 						validateDBConfig,
-						validateGardenerConfig,
-						validateAWSConfig,
-						validateGCPConfig,
-						validateAzureConfig,
 					}
 
 					for _, validator := range validatorFuncs {

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -431,6 +431,8 @@ scheduler:
           # Gardener
           - name: "g:model:project"
             duration: 24h
+          - name: "g:model:project_member"
+            duration: 24h
           - name: "g:model:seed"
             duration: 24h
           - name: "g:model:shoot"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -504,6 +504,10 @@ scheduler:
 
 # Gardener specific configuration
 gardener:
+  # Setting `is_enabled' to false would not create a Gardener API client, and as
+  # a result Inventory will not process any of the Gardener collection tasks.
+  is_enabled: true
+
   # Specifies the endpoint of the Gardener APIs.
   endpoint: https://localhost:6443/
 

--- a/pkg/clients/gardener/gardener.go
+++ b/pkg/clients/gardener/gardener.go
@@ -90,6 +90,12 @@ type GKESoilCluster struct {
 // DefaultClient is the default client for interfacing with the Gardener APIs.
 var DefaultClient *Client
 
+// IsDefaultClientSet is a predicate which returns true when the [DefaultClient]
+// has been configured, and returns false otherwise.
+func IsDefaultClientSet() bool {
+	return DefaultClient != nil
+}
+
 // SetDefaultClient sets the [DefaultClient] to the specified [Client].
 func SetDefaultClient(c *Client) {
 	DefaultClient = c

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -484,6 +484,10 @@ type PeriodicJob struct {
 
 // GardenerConfig represents the Gardener specific configuration.
 type GardenerConfig struct {
+	// IsEnabled specifies whether the Gardener collection is enabled or
+	// not.  Setting this to false will not configure a Gardener API client.
+	IsEnabled bool `yaml:"is_enabled"`
+
 	// UserAgent is the User-Agent header to configure for the API client.
 	UserAgent string `yaml:"user_agent"`
 

--- a/pkg/gardener/tasks/backupbuckets.go
+++ b/pkg/gardener/tasks/backupbuckets.go
@@ -36,8 +36,13 @@ func NewCollectBackupBucketsTask() *asynq.Task {
 
 // HandleCollectBackupBucketsTask is the handler for collecting BackupBuckets.
 func HandleCollectBackupBucketsTask(ctx context.Context, t *asynq.Task) error {
-	client := gardenerclient.DefaultClient.GardenClient()
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
+	client := gardenerclient.DefaultClient.GardenClient()
 	logger.Info("Collecting Gardener backup buckets")
 	buckets := make([]models.BackupBucket, 0)
 	p := pager.New(

--- a/pkg/gardener/tasks/cloudprofiles.go
+++ b/pkg/gardener/tasks/cloudprofiles.go
@@ -57,6 +57,12 @@ func NewCollectCloudProfilesTask() *asynq.Task {
 // Profiles. This handler will also enqueue tasks for collecting and persisting
 // the machine images for each supported Cloud Profile type.
 func HandleCollectCloudProfilesTask(ctx context.Context, t *asynq.Task) error {
+	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
 	// After collecting the Cloud Profiles we will enqueue a separate task
 	// for persisting the Machine Images for each supported Cloud Profile
 	// type. The following is the mapping between the Cloud Profile type,
@@ -69,7 +75,6 @@ func HandleCollectCloudProfilesTask(ctx context.Context, t *asynq.Task) error {
 	}
 
 	client := gardenerclient.DefaultClient.GardenClient()
-	logger := asynqutils.GetLogger(ctx)
 	logger.Info("collecting Gardener cloud profiles")
 	cloudProfiles := make([]models.CloudProfile, 0)
 	p := pager.New(

--- a/pkg/gardener/tasks/machines.go
+++ b/pkg/gardener/tasks/machines.go
@@ -118,6 +118,11 @@ func enqueueCollectMachines(ctx context.Context) error {
 // specified in the payload.
 func collectMachines(ctx context.Context, payload CollectMachinesPayload) error {
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
 	logger.Info("collecting Gardener machines", "seed", payload.Seed)
 	client, err := gardenerclient.DefaultClient.MCMClient(ctx, payload.Seed)
 	if err != nil {

--- a/pkg/gardener/tasks/persistent_volumes.go
+++ b/pkg/gardener/tasks/persistent_volumes.go
@@ -127,6 +127,11 @@ func enqueueCollectPersistentVolumes(ctx context.Context) error {
 // specified in the payload.
 func collectPersistentVolumes(ctx context.Context, payload CollectPersistentVolumesPayload) error {
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
 	logger.Info("collecting Gardener Persistent Volumes", "seed", payload.Seed)
 	client, err := gardenerclient.DefaultClient.SeedClient(ctx, payload.Seed)
 	if err != nil {

--- a/pkg/gardener/tasks/projects.go
+++ b/pkg/gardener/tasks/projects.go
@@ -63,8 +63,13 @@ func HandleCollectProjectsTask(ctx context.Context, t *asynq.Task) error {
 
 // collectProject collects a single Gardener Project.
 func collectProject(ctx context.Context, payload CollectProjectsPayload) error {
-	client := gardenerclient.DefaultClient.GardenClient()
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
+	client := gardenerclient.DefaultClient.GardenClient()
 	logger.Info("collecting Gardener project", "project", payload.ProjectName)
 
 	result, err := client.CoreV1beta1().Projects().Get(ctx, payload.ProjectName, metav1.GetOptions{})
@@ -86,8 +91,13 @@ func collectProject(ctx context.Context, payload CollectProjectsPayload) error {
 
 // collectAllProjects collects all projects from Gardener.
 func collectAllProjects(ctx context.Context) error {
-	client := gardenerclient.DefaultClient.GardenClient()
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
+	client := gardenerclient.DefaultClient.GardenClient()
 	logger.Info("collecting Gardener projects")
 	items := make([]*v1beta1.Project, 0)
 

--- a/pkg/gardener/tasks/seeds.go
+++ b/pkg/gardener/tasks/seeds.go
@@ -36,8 +36,13 @@ func NewCollectSeedsTask() *asynq.Task {
 
 // HandleCollectSeedsTask is the handler for collecting Gardener Seeds.
 func HandleCollectSeedsTask(ctx context.Context, t *asynq.Task) error {
-	client := gardenerclient.DefaultClient.GardenClient()
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
+	client := gardenerclient.DefaultClient.GardenClient()
 	logger.Info("collecting Gardener seeds")
 	seeds := make([]models.Seed, 0)
 	p := pager.New(

--- a/pkg/gardener/tasks/shoots.go
+++ b/pkg/gardener/tasks/shoots.go
@@ -51,8 +51,13 @@ func NewCollectShootsTask() *asynq.Task {
 
 // HandleCollectShootsTask is a handler that collects Gardener Shoots.
 func HandleCollectShootsTask(ctx context.Context, t *asynq.Task) error {
-	client := gardenerclient.DefaultClient.GardenClient()
 	logger := asynqutils.GetLogger(ctx)
+	if !gardenerclient.IsDefaultClientSet() {
+		logger.Warn("gardener client not configured")
+		return nil
+	}
+
+	client := gardenerclient.DefaultClient.GardenClient()
 	logger.Info("collecting Gardener shoots")
 	shoots := make([]models.Shoot, 0)
 	p := pager.New(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for activating/deactivating the collection of Gardener resources via the `gardener.is_enabled` option.

Also, validation of other datasources (e.g. `aws`, `gcp` and `azure`) will be done only if the respective data sources have been activated.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Add support for activating/deactivating collection of Gardener resources
- Validate AWS, GCP and Azure config, only if the respective datasource has been activated
```
