### PR TITLE
feat: enqueue new tasks back to origin queue

### DIFF
--- a/pkg/aws/tasks/azs.go
+++ b/pkg/aws/tasks/azs.go
@@ -175,6 +175,7 @@ func enqueueCollectAvailabilityZones(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Enqueue a task for each region
 	for _, r := range regions {
@@ -203,7 +204,7 @@ func enqueueCollectAvailabilityZones(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectAvailabilityZones, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/buckets.go
+++ b/pkg/aws/tasks/buckets.go
@@ -71,6 +71,7 @@ func enqueueCollectBuckets(ctx context.Context) error {
 		return nil
 	}
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := awsclients.S3Clientset.Range(func(accountID string, _ *awsclients.Client[*s3.Client]) error {
 		p := CollectBucketsPayload{AccountID: accountID}
 		data, err := json.Marshal(p)
@@ -84,7 +85,7 @@ func enqueueCollectBuckets(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectBuckets, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/images.go
+++ b/pkg/aws/tasks/images.go
@@ -81,6 +81,7 @@ func enqueueCollectImages(ctx context.Context, payload CollectImagesPayload) err
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	// Enqueue task for each known region
 	for _, r := range regions {
 		if !awsclients.EC2Clientset.Exists(r.AccountID) {
@@ -115,7 +116,7 @@ func enqueueCollectImages(ctx context.Context, payload CollectImagesPayload) err
 		}
 
 		task := asynq.NewTask(TaskCollectImages, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/instances.go
+++ b/pkg/aws/tasks/instances.go
@@ -82,6 +82,7 @@ func enqueueCollectInstances(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Enqueue task for each known region and account id
 	for _, r := range regions {
@@ -110,7 +111,7 @@ func enqueueCollectInstances(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectInstances, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/loadbalancers.go
+++ b/pkg/aws/tasks/loadbalancers.go
@@ -83,6 +83,7 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Enqueue ELB collection tasks for each region
 	for _, r := range regions {
@@ -102,7 +103,7 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectLoadBalancers, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/network_interfaces.go
+++ b/pkg/aws/tasks/network_interfaces.go
@@ -82,6 +82,7 @@ func enqueueCollectENIs(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Enqueue ENI collection for each region
 	for _, r := range regions {
@@ -110,7 +111,7 @@ func enqueueCollectENIs(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectNetworkInterfaces, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/regions.go
+++ b/pkg/aws/tasks/regions.go
@@ -71,6 +71,7 @@ func enqueueCollectRegions(ctx context.Context) error {
 		return nil
 	}
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := awsclients.EC2Clientset.Range(func(accountID string, _ *awsclients.Client[*ec2.Client]) error {
 		p := &CollectRegionsPayload{AccountID: accountID}
 		data, err := json.Marshal(p)
@@ -84,7 +85,7 @@ func enqueueCollectRegions(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectRegions, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/subnets.go
+++ b/pkg/aws/tasks/subnets.go
@@ -81,6 +81,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, r := range regions {
 		if !awsclients.EC2Clientset.Exists(r.AccountID) {
 			logger.Warn(
@@ -106,7 +107,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectSubnets, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/aws/tasks/tasks.go
+++ b/pkg/aws/tasks/tasks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/common/utils"
 	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
 const (
@@ -27,6 +28,8 @@ const (
 // HandleCollectAllTask is a handler, which enqueues tasks for collecting all
 // AWS objects.
 func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
+	queue := asynqutils.GetQueueName(ctx)
+
 	// Task constructors
 	taskFns := []utils.TaskConstructor{
 		NewCollectRegionsTask,
@@ -40,7 +43,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectNetworkInterfacesTask,
 	}
 
-	return utils.Enqueue(ctx, taskFns)
+	return utils.Enqueue(ctx, taskFns, asynq.Queue(queue))
 }
 
 // HandleLinkAllTask is a handler, which establishes links between the various

--- a/pkg/aws/tasks/vpcs.go
+++ b/pkg/aws/tasks/vpcs.go
@@ -80,6 +80,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Enqueue task for each region
 	for _, r := range regions {
@@ -108,7 +109,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectVPCs, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/blob_containers.go
+++ b/pkg/azure/tasks/blob_containers.go
@@ -82,6 +82,7 @@ func enqueueCollectBlobContainers(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, acc := range storageAccounts {
 		if !azureclients.BlobContainersClientset.Exists(acc.SubscriptionID) {
 			logger.Warn(
@@ -111,7 +112,7 @@ func enqueueCollectBlobContainers(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectBlobContainers, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/load_balancers.go
+++ b/pkg/azure/tasks/load_balancers.go
@@ -76,6 +76,7 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, rg := range resourceGroups {
 		if !azureclients.LoadBalancersClientset.Exists(rg.SubscriptionID) {
 			logger.Warn(
@@ -102,7 +103,7 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectLoadBalancers, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/public_addresses.go
+++ b/pkg/azure/tasks/public_addresses.go
@@ -77,6 +77,7 @@ func enqueueCollectPublicAddresses(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, rg := range resourceGroups {
 		if !azureclients.PublicIPAddressesClientset.Exists(rg.SubscriptionID) {
 			logger.Warn(
@@ -103,7 +104,7 @@ func enqueueCollectPublicAddresses(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectPublicAddresses, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/resource_groups.go
+++ b/pkg/azure/tasks/resource_groups.go
@@ -70,6 +70,7 @@ func enqueueCollectResourceGroups(ctx context.Context) error {
 		return nil
 	}
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := azureclients.ResourceGroupsClientset.Range(func(subscriptionID string, _ *azureclients.Client[*armresources.ResourceGroupsClient]) error {
 		payload := CollectResourceGroupsPayload{
 			SubscriptionID: subscriptionID,
@@ -84,7 +85,7 @@ func enqueueCollectResourceGroups(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectResourceGroups, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/storage_accounts.go
+++ b/pkg/azure/tasks/storage_accounts.go
@@ -75,6 +75,7 @@ func enqueueCollectStorageAccounts(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, rg := range resourceGroups {
 		if !azureclients.StorageAccountsClientset.Exists(rg.SubscriptionID) {
 			logger.Warn(
@@ -101,7 +102,7 @@ func enqueueCollectStorageAccounts(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectStorageAccounts, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/subnets.go
+++ b/pkg/azure/tasks/subnets.go
@@ -81,6 +81,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, vpc := range vpcs {
 		if !azureclients.SubnetsClientset.Exists(vpc.SubscriptionID) {
 			logger.Warn(
@@ -109,7 +110,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectSubnets, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/tasks.go
+++ b/pkg/azure/tasks/tasks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/common/utils"
 	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
 const (
@@ -25,6 +26,8 @@ const (
 // HandleCollectAllTask is a handler, which enqueues tasks for collecting all
 // Azure objects.
 func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
+	queue := asynqutils.GetQueueName(ctx)
+
 	// Task constructors
 	taskFns := []utils.TaskConstructor{
 		NewCollectSubscriptionsTasks,
@@ -38,7 +41,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectBlobContainersTask,
 	}
 
-	return utils.Enqueue(ctx, taskFns)
+	return utils.Enqueue(ctx, taskFns, asynq.Queue(queue))
 }
 
 // HandleLinkAllTask is a handler, which establishes links between the various

--- a/pkg/azure/tasks/virtual_machines.go
+++ b/pkg/azure/tasks/virtual_machines.go
@@ -77,6 +77,7 @@ func enqueueCollectVirtualMachines(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, rg := range resourceGroups {
 		if !azureclients.VirtualMachinesClientset.Exists(rg.SubscriptionID) {
 			logger.Warn(
@@ -103,7 +104,7 @@ func enqueueCollectVirtualMachines(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectVirtualMachines, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/azure/tasks/vpcs.go
+++ b/pkg/azure/tasks/vpcs.go
@@ -75,6 +75,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 
 	// Enqueue task for each resource group
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 	for _, rg := range resourceGroups {
 		if !azureclients.VirtualNetworksClientset.Exists(rg.SubscriptionID) {
 			logger.Warn(
@@ -101,7 +102,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 			continue
 		}
 		task := asynq.NewTask(TaskCollectVPCs, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -18,11 +18,11 @@ import (
 type TaskConstructor func() *asynq.Task
 
 // Enqueue enqueues the tasks produced by the given task constructors.
-func Enqueue(ctx context.Context, items []TaskConstructor) error {
+func Enqueue(ctx context.Context, items []TaskConstructor, opts ...asynq.Option) error {
 	logger := asynqutils.GetLogger(ctx)
 	for _, fn := range items {
 		task := fn()
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, opts...)
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gardener/tasks/cloudprofiles.go
+++ b/pkg/gardener/tasks/cloudprofiles.go
@@ -83,6 +83,7 @@ func HandleCollectCloudProfilesTask(ctx context.Context, t *asynq.Task) error {
 		}),
 	)
 	opts := metav1.ListOptions{Limit: constants.PageSize}
+	queue := asynqutils.GetQueueName(ctx)
 	err := p.EachListItem(ctx, opts, func(obj runtime.Object) error {
 		cp, ok := obj.(*gardenerv1beta1.CloudProfile)
 		if !ok {
@@ -135,7 +136,7 @@ func HandleCollectCloudProfilesTask(ctx context.Context, t *asynq.Task) error {
 		}
 
 		task := asynq.NewTask(miTaskName, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gardener/tasks/machines.go
+++ b/pkg/gardener/tasks/machines.go
@@ -75,6 +75,7 @@ func enqueueCollectMachines(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Create a task for each known seed cluster
 	for _, s := range seeds {
@@ -92,7 +93,7 @@ func enqueueCollectMachines(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectMachines, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gardener/tasks/persistent_volumes.go
+++ b/pkg/gardener/tasks/persistent_volumes.go
@@ -84,6 +84,7 @@ func enqueueCollectPersistentVolumes(ctx context.Context) error {
 	}
 
 	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
 
 	// Create a task for each known seed cluster
 	for _, s := range seeds {
@@ -101,7 +102,7 @@ func enqueueCollectPersistentVolumes(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectPersistentVolumes, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gardener/tasks/tasks.go
+++ b/pkg/gardener/tasks/tasks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/common/utils"
 	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
 const (
@@ -27,6 +28,8 @@ const (
 // HandleCollectAllTask is the handler, which enqueues tasks for collecting all
 // known Gardener resources.
 func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
+	queue := asynqutils.GetQueueName(ctx)
+
 	// Task constructors
 	taskFns := []utils.TaskConstructor{
 		NewCollectProjectsTask,
@@ -38,7 +41,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectPersistentVolumesTask,
 	}
 
-	return utils.Enqueue(ctx, taskFns)
+	return utils.Enqueue(ctx, taskFns, asynq.Queue(queue))
 }
 
 // HandleLinkAllTask is the handler, which establishes relationships between the

--- a/pkg/gcp/tasks/addresses.go
+++ b/pkg/gcp/tasks/addresses.go
@@ -77,6 +77,7 @@ func enqueueCollectAddresses(ctx context.Context) error {
 	// Enqueue tasks for all registered GCP Projects. Same projects are
 	// registered for the regional and global addresses clients, so here we
 	// can iterate through just one of the registries.
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.AddressesClientset.Range(func(projectID string, _ *gcpclients.Client[*compute.AddressesClient]) error {
 		payload := CollectAddressesPayload{ProjectID: projectID}
 		data, err := json.Marshal(payload)
@@ -89,7 +90,7 @@ func enqueueCollectAddresses(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectAddresses, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/buckets.go
+++ b/pkg/gcp/tasks/buckets.go
@@ -68,6 +68,7 @@ func HandleCollectBucketsTask(ctx context.Context, t *asynq.Task) error {
 func enqueueCollectBuckets(ctx context.Context) error {
 	logger := asynqutils.GetLogger(ctx)
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.StorageClientset.Range(func(projectID string, c *gcpclients.Client[*storage.Client]) error {
 		p := &CollectBucketsPayload{ProjectID: projectID}
 		data, err := json.Marshal(p)
@@ -81,7 +82,7 @@ func enqueueCollectBuckets(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectBuckets, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/disks.go
+++ b/pkg/gcp/tasks/disks.go
@@ -71,6 +71,7 @@ func HandleCollectDisksTask(ctx context.Context, t *asynq.Task) error {
 func enqueueCollectDisks(ctx context.Context) error {
 	logger := asynqutils.GetLogger(ctx)
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.DisksClientset.Range(func(projectID string, c *gcpclients.Client[*compute.DisksClient]) error {
 		p := &CollectDisksPayload{ProjectID: projectID}
 		data, err := json.Marshal(p)
@@ -84,7 +85,7 @@ func enqueueCollectDisks(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectDisks, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/forwarding_rules.go
+++ b/pkg/gcp/tasks/forwarding_rules.go
@@ -80,6 +80,7 @@ func enqueueCollectForwardingRules(ctx context.Context) error {
 	}
 
 	// Enqueue tasks for all registered GCP Projects
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.ForwardingRulesClientset.Range(func(projectID string, _ *gcpclients.Client[*compute.ForwardingRulesClient]) error {
 		payload := CollectForwardingRulesPayload{
 			ProjectID: projectID,
@@ -94,7 +95,7 @@ func enqueueCollectForwardingRules(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectForwardingRules, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/gke_clusters.go
+++ b/pkg/gcp/tasks/gke_clusters.go
@@ -67,6 +67,7 @@ func enqueueCollectGKEClusters(ctx context.Context) error {
 	}
 
 	// Enqueue tasks for all registered GCP Projects
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.ClusterManagerClientset.Range(func(projectID string, _ *gcpclients.Client[*container.ClusterManagerClient]) error {
 		payload := CollectGKEClustersPayload{
 			ProjectID: projectID,
@@ -81,7 +82,7 @@ func enqueueCollectGKEClusters(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectGKEClusters, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/instances.go
+++ b/pkg/gcp/tasks/instances.go
@@ -84,6 +84,7 @@ func enqueueCollectInstances(ctx context.Context) error {
 	}
 
 	// Enqueue tasks for all registered GCP Projects
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.InstancesClientset.Range(func(projectID string, _ *gcpclients.Client[*compute.InstancesClient]) error {
 		payload := CollectInstancesPayload{
 			ProjectID: projectID,
@@ -98,7 +99,7 @@ func enqueueCollectInstances(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectInstances, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/subnets.go
+++ b/pkg/gcp/tasks/subnets.go
@@ -76,6 +76,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 		return nil
 	}
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.SubnetworksClientset.Range(func(projectID string, c *gcpclients.Client[*compute.SubnetworksClient]) error {
 		p := &CollectSubnetsPayload{ProjectID: projectID}
 		data, err := json.Marshal(p)
@@ -89,7 +90,7 @@ func enqueueCollectSubnets(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectSubnets, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/target_pools.go
+++ b/pkg/gcp/tasks/target_pools.go
@@ -79,6 +79,7 @@ func enqueueCollectTargetPools(ctx context.Context) error {
 	}
 
 	// Enqueue tasks for all registered GCP Projects
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.TargetPoolsClientset.Range(func(projectID string, _ *gcpclients.Client[*compute.TargetPoolsClient]) error {
 		payload := CollectTargetPoolsPayload{
 			ProjectID: projectID,
@@ -93,7 +94,7 @@ func enqueueCollectTargetPools(ctx context.Context) error {
 			return registry.ErrContinue
 		}
 		task := asynq.NewTask(TaskCollectTargetPools, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/gcp/tasks/tasks.go
+++ b/pkg/gcp/tasks/tasks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/common/utils"
 	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
 const (
@@ -25,6 +26,8 @@ const (
 // HandleCollectAllTask is a handler, which enqueues tasks for collecting all
 // GCP objects.
 func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
+	queue := asynqutils.GetQueueName(ctx)
+
 	// Task constructors
 	taskFns := []utils.TaskConstructor{
 		NewCollectProjectsTask,
@@ -39,7 +42,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectTargetPoolsTask,
 	}
 
-	return utils.Enqueue(ctx, taskFns)
+	return utils.Enqueue(ctx, taskFns, asynq.Queue(queue))
 }
 
 // HandleLinkAllTask is a handler, which establishes links between the various

--- a/pkg/gcp/tasks/vpcs.go
+++ b/pkg/gcp/tasks/vpcs.go
@@ -78,6 +78,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 		return nil
 	}
 
+	queue := asynqutils.GetQueueName(ctx)
 	err := gcpclients.NetworksClientset.Range(func(projectID string, _ *gcpclients.Client[*compute.NetworksClient]) error {
 		p := &CollectVPCsPayload{ProjectID: projectID}
 		data, err := json.Marshal(p)
@@ -91,7 +92,7 @@ func enqueueCollectVPCs(ctx context.Context) error {
 		}
 
 		task := asynq.NewTask(TaskCollectVPCs, data)
-		info, err := asynqclient.Client.Enqueue(task)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
 		if err != nil {
 			logger.Error(
 				"failed to enqueue task",

--- a/pkg/utils/asynq/asynq.go
+++ b/pkg/utils/asynq/asynq.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/hibiken/asynq"
 	"gopkg.in/yaml.v3"
+
+	"github.com/gardener/inventory/pkg/core/config"
 )
 
 // SkipRetry wraps the provided error with [asynq.SkipRetry] in order to signal
@@ -123,4 +125,15 @@ func NewDefaultErrorHandler() asynq.ErrorHandlerFunc {
 	}
 
 	return asynq.ErrorHandlerFunc(handler)
+}
+
+// GetQueueName returns the queue name from the specified context, if present.
+// Otherwise it returns [config.DefaultQueueName].
+func GetQueueName(ctx context.Context) string {
+	queue, ok := asynq.GetQueueName(ctx)
+	if ok {
+		return queue
+	}
+
+	return config.DefaultQueueName
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Whenever a task which expects a payload is called without one, in most handlers we internally create such payload and dispatch new sub-tasks. 

For example if `gcp:task:collect-instances` task is called without specifying a project name as part of the payload, then the task handler will internally create new sub-tasks from the projects already collected and present in Inventory itself.

However, until now new sub-tasks have been enqueued to the `default` queue, which is not desired. Instead, whenever we create new sub-tasks we should take into account the queue from which the source task originates from.

This PR considers the queue of the task and enqueues new sub-tasks back to the queue from which the source task originates from.

Related PR: https://github.com/gardener/inventory/pull/336

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Enqueue sub-tasks back to the queue of the source task
```
