### PR TITLE
feat: `g:task:collect-shoots` accepts payload

### DIFF
--- a/pkg/gardener/tasks/errors.go
+++ b/pkg/gardener/tasks/errors.go
@@ -10,6 +10,10 @@ import "errors"
 // was not specified as part of the task payload.
 var ErrNoProjectName = errors.New("no project name specified")
 
+// ErrNoProjectNamespace is an error, which is returned when an expected Project
+// namespace was not specified as part of the task payload.
+var ErrNoProjectNamespace = errors.New("no project namespace specified")
+
 // ErrNoSeedCluster is an error, which is returned when an expected Seed Cluster
 // was not specified.
 var ErrNoSeedCluster = errors.New("no seed cluster specified")

--- a/pkg/gardener/utils/utils.go
+++ b/pkg/gardener/utils/utils.go
@@ -21,6 +21,13 @@ func GetSeedsFromDB(ctx context.Context) ([]models.Seed, error) {
 	return items, err
 }
 
+// GetProjectsFromDB fetches the [models.Project] items from the database.
+func GetProjectsFromDB(ctx context.Context) ([]models.Project, error) {
+	items := make([]models.Project, 0)
+	err := db.DB.NewSelect().Model(&items).Scan(ctx)
+	return items, err
+}
+
 // ErrCannotInferShoot is an error which is returned when a shoot cannot be
 // inferred from the specified instance name.
 var ErrCannotInferShoot = errors.New("cannot infer shoot")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for providing payload to the `g:task:collect-shoots` task, this way allowing the collection of shoots from specific projects only.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for specifying payload for the g:task:collect-shoots task
```
