### PR TITLE
OpenStack config + clients

### DIFF
--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -83,11 +83,11 @@ func validateOpenStackConfig(conf *config.Config) error {
 			}
 
 			switch creds.Authentication {
-			case config.OpenStackAuthenticationMethodUser:
-				if creds.User.UsernameFile == "" {
+            case config.OpenStackAuthenticationMethodPassword:
+				if creds.Password.UsernameFile == "" {
 					return fmt.Errorf("OpenStack: %w: %s", errNoUsernameFile, name)
 				}
-				if creds.User.PasswordFile == "" {
+				if creds.Password.PasswordFile == "" {
 					return fmt.Errorf("OpenStack: %w: %s", errNoPasswordFile, name)
 				}
 			case config.OpenStackAuthenticationMethodAppCredentials:
@@ -159,14 +159,14 @@ func configureOpenStackComputeClientsets(ctx context.Context, conf *config.Confi
 
 		var authOpts gophercloud.AuthOptions
 		switch namedCreds.Authentication {
-		case config.OpenStackAuthenticationMethodUser:
-			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+        case config.OpenStackAuthenticationMethodPassword:
+			rawUsername, err := os.ReadFile(namedCreds.Password.UsernameFile)
 			if err != nil {
 				return fmt.Errorf("unable to read username file: %w", err)
 			}
 			username := strings.TrimSpace(string(rawUsername))
 
-			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			rawPassword, err := os.ReadFile(namedCreds.Password.PasswordFile)
 			password := strings.TrimSpace(string(rawPassword))
 
 			if err != nil {
@@ -264,14 +264,14 @@ func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Confi
 
 		var authOpts gophercloud.AuthOptions
 		switch namedCreds.Authentication {
-		case config.OpenStackAuthenticationMethodUser:
-			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+        case config.OpenStackAuthenticationMethodPassword:
+			rawUsername, err := os.ReadFile(namedCreds.Password.UsernameFile)
 			if err != nil {
 				return fmt.Errorf("unable to read username file: %w", err)
 			}
 			username := strings.TrimSpace(string(rawUsername))
 
-			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			rawPassword, err := os.ReadFile(namedCreds.Password.PasswordFile)
 			password := strings.TrimSpace(string(rawPassword))
 
 			if err != nil {
@@ -369,14 +369,14 @@ func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.
 
 		var authOpts gophercloud.AuthOptions
 		switch namedCreds.Authentication {
-		case config.OpenStackAuthenticationMethodUser:
-			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+		case config.OpenStackAuthenticationMethodPassword:
+			rawUsername, err := os.ReadFile(namedCreds.Password.UsernameFile)
 			if err != nil {
 				return fmt.Errorf("unable to read username file: %w", err)
 			}
 			username := strings.TrimSpace(string(rawUsername))
 
-			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			rawPassword, err := os.ReadFile(namedCreds.Password.PasswordFile)
 			password := strings.TrimSpace(string(rawPassword))
 
 			if err != nil {

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -171,11 +171,7 @@ func configureOpenStackComputeClientsets(ctx context.Context, conf *config.Confi
 				Password:         password,
 			}
 		case config.OpenStackAuthenticationMethodAppCredentials:
-			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsID)
-			if err != nil {
-				return fmt.Errorf("unable to read app credentials id file: %w", err)
-			}
-			appID := strings.TrimSpace(string(rawAppID))
+			appID := strings.TrimSpace(namedCreds.AppCredentials.AppCredentialsID)
 
 			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
 			if err != nil {
@@ -194,7 +190,7 @@ func configureOpenStackComputeClientsets(ctx context.Context, conf *config.Confi
 
 		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
 		if err != nil {
-			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+			return fmt.Errorf("unable to create client for service with credentials %s: %w", cred, err)
 		}
 
 		computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
@@ -246,11 +242,7 @@ func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Confi
 		var authOpts gophercloud.AuthOptions
 		switch namedCreds.Authentication {
 		case config.OpenStackAuthenticationMethodPassword:
-			rawUsername, err := os.ReadFile(namedCreds.Password.Username)
-			if err != nil {
-				return fmt.Errorf("unable to read username file: %w", err)
-			}
-			username := strings.TrimSpace(string(rawUsername))
+			username := strings.TrimSpace(namedCreds.Password.Username)
 
 			rawPassword, err := os.ReadFile(namedCreds.Password.PasswordFile)
 			password := strings.TrimSpace(string(rawPassword))
@@ -267,11 +259,7 @@ func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Confi
 				Password:         password,
 			}
 		case config.OpenStackAuthenticationMethodAppCredentials:
-			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsID)
-			if err != nil {
-				return fmt.Errorf("unable to read app credentials id file: %w", err)
-			}
-			appID := string(rawAppID)
+			appID := strings.TrimSpace(namedCreds.AppCredentials.AppCredentialsID)
 
 			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
 			if err != nil {
@@ -290,7 +278,7 @@ func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Confi
 
 		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
 		if err != nil {
-			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+			return fmt.Errorf("unable to create client for service with credentials %s: %w", cred, err)
 		}
 
 		networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{})
@@ -340,11 +328,7 @@ func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.
 		var authOpts gophercloud.AuthOptions
 		switch namedCreds.Authentication {
 		case config.OpenStackAuthenticationMethodPassword:
-			rawUsername, err := os.ReadFile(namedCreds.Password.Username)
-			if err != nil {
-				return fmt.Errorf("unable to read username file: %w", err)
-			}
-			username := strings.TrimSpace(string(rawUsername))
+			username := strings.TrimSpace(namedCreds.Password.Username)
 
 			rawPassword, err := os.ReadFile(namedCreds.Password.PasswordFile)
 			password := strings.TrimSpace(string(rawPassword))
@@ -361,11 +345,7 @@ func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.
 				Password:         password,
 			}
 		case config.OpenStackAuthenticationMethodAppCredentials:
-			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsID)
-			if err != nil {
-				return fmt.Errorf("unable to read app credentials id file: %w", err)
-			}
-			appID := string(rawAppID)
+			appID := strings.TrimSpace(namedCreds.AppCredentials.AppCredentialsID)
 
 			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
 			if err != nil {
@@ -384,7 +364,7 @@ func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.
 
 		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
 		if err != nil {
-			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+			return fmt.Errorf("unable to create client for service with credentials %s: %w", cred, err)
 		}
 
 		blockStorageClient, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -37,7 +37,7 @@ func validateOpenStackConfig(conf *config.Config) error {
 	services := map[string][]config.OpenStackServiceConfig{
 		"compute": conf.OpenStack.Services.Compute,
 		"network": conf.OpenStack.Services.Network,
-		"storage": conf.OpenStack.Services.BlockStorage,
+		"block_storage": conf.OpenStack.Services.BlockStorage,
 	}
 
 	for service, serviceConfigs := range services {

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -1,0 +1,445 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+	"github.com/gardener/inventory/pkg/core/config"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack"
+	gophercloudconfig "github.com/gophercloud/gophercloud/v2/openstack/config"
+)
+
+var errNoUsernameFile = errors.New("no username file specified")
+var errNoPasswordFile = errors.New("no password file specified")
+var errNoAppCredentialsIDFile = errors.New("no app credentials id file specified")
+var errNoAppCredentialsSecretFile = errors.New("no app credentials secret file specified")
+var errNoAppCredentialsNameFile = errors.New("no app credentials name file specified")
+var errNoAuthEndpoint = errors.New("no authentication endpoint specified")
+var errNoDomain = errors.New("no domain specified")
+var errNoRegion = errors.New("no region specified")
+var errNoProject = errors.New("no project specified")
+var errNoProjectID = errors.New("no project id specified")
+
+// validateOpenStackConfig validates the OpenStack configuration settings.
+func validateOpenStackConfig(conf *config.Config) error {
+	// Make sure that the services have named credentials configured.
+	services := map[string][]config.OpenStackServiceConfig{
+		"compute": conf.OpenStack.Services.Compute,
+		"network": conf.OpenStack.Services.Network,
+		"storage": conf.OpenStack.Services.BlockStorage,
+	}
+
+	for service, serviceConfigs := range services {
+		if len(serviceConfigs) == 0 {
+			continue
+		}
+
+		// Validate that the named credentials are actually defined.
+		for _, config := range serviceConfigs {
+			namedCreds := config.UseCredentials
+			if namedCreds == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoServiceCredentials, service)
+			}
+
+			if _, ok := conf.OpenStack.Credentials[namedCreds]; !ok {
+				return fmt.Errorf("OpenStack: %w: service %s refers to %s", errUnknownNamedCredentials, service, namedCreds)
+			}
+
+			if config.AuthEndpoint == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoAuthEndpoint, service)
+			}
+
+			if config.Domain == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoDomain, service)
+			}
+
+			if config.Region == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoRegion, service)
+			}
+
+			if config.Project == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoProject, service)
+			}
+
+			if config.ProjectID == "" {
+				return fmt.Errorf("OpenStack: %w: %s", errNoProjectID, service)
+			}
+		}
+
+		for name, creds := range conf.OpenStack.Credentials {
+			if creds.Authentication == "" {
+				return fmt.Errorf("OpenStack: %w: credentials %s", errNoAuthenticationMethod, name)
+			}
+
+			switch creds.Authentication {
+			case config.OpenStackAuthenticationMethodUser:
+				if creds.User.UsernameFile == "" {
+					return fmt.Errorf("OpenStack: %w: %s", errNoUsernameFile, name)
+				}
+				if creds.User.PasswordFile == "" {
+					return fmt.Errorf("OpenStack: %w: %s", errNoPasswordFile, name)
+				}
+				break
+			case config.OpenStackAuthenticationMethodAppCredentials:
+				if creds.AppCredentials.AppCredentialsIDFile == "" {
+					return fmt.Errorf("OpenStack: %w: %s", errNoAppCredentialsIDFile, name)
+				}
+				if creds.AppCredentials.AppCredentialsSecretFile == "" {
+					return fmt.Errorf("OpenStack: %w: %s", errNoAppCredentialsSecretFile, name)
+				}
+				if creds.AppCredentials.AppCredentialsNameFile == "" {
+					return fmt.Errorf("OpenStack: %w: %s", errNoAppCredentialsNameFile, name)
+				}
+				break
+			default:
+				return fmt.Errorf("OpenStack: %w: %s uses %s", errUnknownAuthenticationMethod, name, creds.Authentication)
+			}
+		}
+	}
+
+	return nil
+}
+
+// configureOpenStackClients creates the OpenStack API clients from the specified
+// configuration.
+func configureOpenStackClients(ctx context.Context, conf *config.Config) error {
+	if !conf.OpenStack.IsEnabled {
+		slog.Warn("OpenStack is not enabled, will not create API clients")
+		return nil
+	}
+
+	slog.Info("configuring OpenStack clients")
+	configFuncs := map[string]func(ctx context.Context, conf *config.Config) error{
+		"compute":       configureOpenStackComputeClientsets,
+		"network":       configureOpenStackNetworkClientsets,
+		"block_storage": configureOpenStackBlockStorageClientsets,
+	}
+
+	if conf.Debug {
+		if err := os.Setenv("OS_DEBUG", "all"); err != nil {
+			return err
+		}
+	}
+
+	for svc, configFunc := range configFuncs {
+		if err := configFunc(ctx, conf); err != nil {
+			return fmt.Errorf("unable to configure OpenStack clients for %s: %w", svc, err)
+		}
+	}
+
+	return nil
+}
+
+// configureOpenStackComputeClientsets configures the OpenStack Compute API clientsets.
+func configureOpenStackComputeClientsets(ctx context.Context, conf *config.Config) error {
+	for _, clientConfig := range conf.OpenStack.Services.Compute {
+		domain := clientConfig.Domain
+		region := clientConfig.Region
+		project := clientConfig.Project
+		projectID := clientConfig.ProjectID
+		authEndpoint := clientConfig.AuthEndpoint
+
+		cred := clientConfig.UseCredentials
+		namedCreds := conf.OpenStack.Credentials[cred]
+
+		var authOpts gophercloud.AuthOptions
+		switch namedCreds.Authentication {
+		case config.OpenStackAuthenticationMethodUser:
+			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read username file: %w", err)
+			}
+			username := strings.TrimSpace(string(rawUsername))
+
+			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			password := strings.TrimSpace(string(rawPassword))
+
+			if err != nil {
+				return fmt.Errorf("unable to read password file for service %s: %w", cred, err)
+			}
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint: authEndpoint,
+				DomainName:       domain,
+				TenantName:       project,
+				Username:         username,
+				Password:         password,
+			}
+		case config.OpenStackAuthenticationMethodAppCredentials:
+			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsIDFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials id file: %w", err)
+			}
+			appID := string(rawAppID)
+
+			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials secret file: %w", err)
+			}
+			appSecret := string(rawAppSecret)
+
+			rawAppName, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsNameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials name file: %w", err)
+			}
+			appName := string(rawAppName)
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint:            authEndpoint,
+				DomainName:                  domain,
+				TenantName:                  project,
+				ApplicationCredentialID:     appID,
+				ApplicationCredentialSecret: appSecret,
+				ApplicationCredentialName:   appName,
+			}
+		default:
+			fmt.Errorf("unknown authentication method: %s", namedCreds.Authentication)
+		}
+
+		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
+		if err != nil {
+			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+		}
+
+		computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
+			Region: region,
+		})
+
+		client := openstackclients.Client[*gophercloud.ServiceClient]{
+			NamedCredentials: cred,
+			ProjectID:        projectID,
+			Region:           region,
+			Domain:           domain,
+			Client:           computeClient,
+		}
+		openstackclients.ComputeClientset.Overwrite(
+			projectID,
+			client,
+		)
+
+		slog.Info(
+			"configured OpenStack client",
+			"service", "compute",
+			"credentials", cred,
+			"region", region,
+			"domain", domain,
+			"project", project,
+			"auth_endpoint", authEndpoint,
+			"auth_method", namedCreds.Authentication,
+		)
+	}
+	return nil
+}
+
+// configureOpenStackNetworkClientsets configures the OpenStack Network API clientsets.
+func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Config) error {
+	for _, clientConfig := range conf.OpenStack.Services.Network {
+		domain := clientConfig.Domain
+		region := clientConfig.Region
+		project := clientConfig.Project
+		projectID := clientConfig.ProjectID
+		authEndpoint := clientConfig.AuthEndpoint
+
+		cred := clientConfig.UseCredentials
+		namedCreds := conf.OpenStack.Credentials[cred]
+
+		var authOpts gophercloud.AuthOptions
+		switch namedCreds.Authentication {
+		case config.OpenStackAuthenticationMethodUser:
+			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read username file: %w", err)
+			}
+			username := strings.TrimSpace(string(rawUsername))
+
+			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			password := strings.TrimSpace(string(rawPassword))
+
+			if err != nil {
+				return fmt.Errorf("unable to read password file for service %s: %w", cred, err)
+			}
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint: authEndpoint,
+				DomainName:       domain,
+				TenantName:       project,
+				Username:         username,
+				Password:         password,
+			}
+		case config.OpenStackAuthenticationMethodAppCredentials:
+			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsIDFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials id file: %w", err)
+			}
+			appID := string(rawAppID)
+
+			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials secret file: %w", err)
+			}
+			appSecret := string(rawAppSecret)
+
+			rawAppName, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsNameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials name file: %w", err)
+			}
+			appName := string(rawAppName)
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint:            authEndpoint,
+				DomainName:                  domain,
+				TenantName:                  project,
+				ApplicationCredentialID:     appID,
+				ApplicationCredentialSecret: appSecret,
+				ApplicationCredentialName:   appName,
+			}
+		default:
+			fmt.Errorf("unknown authentication method: %s", namedCreds.Authentication)
+		}
+
+		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
+		if err != nil {
+			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+		}
+
+		networkClient, err := openstack.NewNetworkV2(providerClient, gophercloud.EndpointOpts{
+			Region: region,
+		})
+
+		client := openstackclients.Client[*gophercloud.ServiceClient]{
+			NamedCredentials: cred,
+			ProjectID:        projectID,
+			Region:           region,
+			Domain:           domain,
+			Client:           networkClient,
+		}
+		openstackclients.NetworkClientset.Overwrite(
+			projectID,
+			client,
+		)
+
+		slog.Info(
+			"configured OpenStack client",
+			"service", "network",
+			"credentials", cred,
+			"region", region,
+			"domain", domain,
+			"project", project,
+			"auth_endpoint", authEndpoint,
+			"auth_method", namedCreds.Authentication,
+		)
+	}
+	return nil
+}
+
+// configureOpenStackBlockStorageClientsets configures the OpenStack Block Storage API clientsets.
+func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.Config) error {
+	for _, clientConfig := range conf.OpenStack.Services.BlockStorage {
+		domain := clientConfig.Domain
+		region := clientConfig.Region
+		project := clientConfig.Project
+		projectID := clientConfig.ProjectID
+		authEndpoint := clientConfig.AuthEndpoint
+
+		cred := clientConfig.UseCredentials
+		namedCreds := conf.OpenStack.Credentials[cred]
+
+		var authOpts gophercloud.AuthOptions
+		switch namedCreds.Authentication {
+		case config.OpenStackAuthenticationMethodUser:
+			rawUsername, err := os.ReadFile(namedCreds.User.UsernameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read username file: %w", err)
+			}
+			username := strings.TrimSpace(string(rawUsername))
+
+			rawPassword, err := os.ReadFile(namedCreds.User.PasswordFile)
+			password := strings.TrimSpace(string(rawPassword))
+
+			if err != nil {
+				return fmt.Errorf("unable to read password file for service %s: %w", cred, err)
+			}
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint: authEndpoint,
+				DomainName:       domain,
+				TenantName:       project,
+				Username:         username,
+				Password:         password,
+			}
+		case config.OpenStackAuthenticationMethodAppCredentials:
+			rawAppID, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsIDFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials id file: %w", err)
+			}
+			appID := string(rawAppID)
+
+			rawAppSecret, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsSecretFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials secret file: %w", err)
+			}
+			appSecret := string(rawAppSecret)
+
+			rawAppName, err := os.ReadFile(namedCreds.AppCredentials.AppCredentialsNameFile)
+			if err != nil {
+				return fmt.Errorf("unable to read app credentials name file: %w", err)
+			}
+			appName := string(rawAppName)
+
+			authOpts = gophercloud.AuthOptions{
+				IdentityEndpoint:            authEndpoint,
+				DomainName:                  domain,
+				TenantName:                  project,
+				ApplicationCredentialID:     appID,
+				ApplicationCredentialSecret: appSecret,
+				ApplicationCredentialName:   appName,
+			}
+		default:
+			fmt.Errorf("unknown authentication method: %s", namedCreds.Authentication)
+		}
+
+		providerClient, err := gophercloudconfig.NewProviderClient(ctx, authOpts)
+		if err != nil {
+			return fmt.Errorf("unable to create client for service %s: %w", cred, err)
+		}
+
+		blockStorageClient, err := openstack.NewBlockStorageV3(providerClient, gophercloud.EndpointOpts{
+			Region: region,
+		})
+
+		client := openstackclients.Client[*gophercloud.ServiceClient]{
+			NamedCredentials: cred,
+			ProjectID:        projectID,
+			Region:           region,
+			Domain:           domain,
+			Client:           blockStorageClient,
+		}
+		openstackclients.BlockStorageClientset.Overwrite(
+			projectID,
+			client,
+		)
+
+		slog.Info(
+			"configured OpenStack client",
+			"service", "block_storage",
+			"credentials", cred,
+			"region", region,
+			"domain", domain,
+			"project", project,
+			"auth_endpoint", authEndpoint,
+			"auth_method", namedCreds.Authentication,
+		)
+	}
+	return nil
+}

--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -185,6 +185,10 @@ func NewWorkerCommand() *cli.Command {
 						return err
 					}
 
+					if err := configureOpenStackClients(ctx.Context, conf); err != nil {
+						return err
+					}
+
 					// Configure logging and middlewares
 					slog.Info("configuring logging and middlewares")
 					logger, err := newLogger(os.Stdout, conf)

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -272,7 +272,7 @@ openstack:
   is_enabled: true
   
   # The `credentials' section provides named credentials, which are used by the
-  # various OpenStack services. The currently supported authentication mechanisms are `user' for username and password
+  # various OpenStack services. The currently supported authentication mechanisms are `password' for username and password
   # and `app_credentials' for application credentials.
   credentials:
     local:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -278,13 +278,13 @@ openstack:
     local:
       authentication: user
       user:
-        username_file: "<path-to-username-file>"
+        username: "<username>"
         password_file: "<path-to-password-file>"
     sa:
       authentication: app_credentials
       user:
-        username_file: "<path-to-username-file>"
-        password_file: "<path-to-password-file>"
+        app_credentials_id: "<app-id>"
+        app_credentials_secret_file: "<path-to-secret-file>"
   services:
     compute:
     - domain: <domain>

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -268,6 +268,55 @@ aws:
         role_arn: arn:aws:iam::account:role/name
         role_session_name: gardener-inventory-worker
 
+openstack:
+  is_enabled: true
+  
+  # The `credentials' section provides named credentials, which are used by the
+  # various OpenStack services. The currently supported authentication mechanisms are `user' for username and password
+  # and `app_credentials' for application credentials.
+  credentials:
+    local:
+      authentication: user
+      user:
+        username_file: "<path-to-username-file>"
+        password_file: "<path-to-password-file>"
+    sa:
+      authentication: app_credentials
+      user:
+        username_file: "<path-to-username-file>"
+        password_file: "<path-to-password-file>"
+  services:
+    compute:
+    - domain: <domain>
+      auth_endpoint: <endpoint>
+      # needed for differentiating between projects with the same name
+      # in different domains.
+      project_id: <project_id>
+      # needed for client creation
+      project: <project_name>
+      region: <region>
+      use_credential: local
+    network:
+    - domain: <domain>
+      auth_endpoint: <endpoint>
+      # needed for differentiating between projects with the same name
+      # in different domains.
+      project_id: <project_id>
+      # needed for client creation
+      project: <project_name>
+      region: <region>
+      use_credential: sa
+    block_storage:
+    - domain: <domain>
+      auth_endpoint: <endpoint>
+      # needed for differentiating between projects with the same name
+      # in different domains.
+      project_id: <project_id>
+      # needed for client creation
+      project: <project_name>
+      region: <region>
+      use_credential: sa
+
 # Scheduler configuration
 scheduler:
   # The queue to submit tasks when no queue has been explicitely specified for a

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -276,13 +276,13 @@ openstack:
   # and `app_credentials' for application credentials.
   credentials:
     local:
-      authentication: user
-      user:
+      authentication: password
+      password:
         username: "<username>"
         password_file: "<path-to-password-file>"
     sa:
       authentication: app_credentials
-      user:
+      app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
   services:
@@ -295,7 +295,7 @@ openstack:
       # needed for client creation
       project: <project_name>
       region: <region>
-      use_credential: local
+      use_credentials: local
     network:
     - domain: <domain>
       auth_endpoint: <endpoint>
@@ -305,7 +305,7 @@ openstack:
       # needed for client creation
       project: <project_name>
       region: <region>
-      use_credential: sa
+      use_credentials: sa
     block_storage:
     - domain: <domain>
       auth_endpoint: <endpoint>
@@ -315,7 +315,7 @@ openstack:
       # needed for client creation
       project: <project_name>
       region: <region>
-      use_credential: sa
+      use_credentials: sa
 
 # Scheduler configuration
 scheduler:

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/gardener/gardener-extension-provider-gcp v1.38.0
 	github.com/gardener/machine-controller-manager v0.53.1
 	github.com/google/uuid v1.6.0
+	github.com/gophercloud/gophercloud/v2 v2.4.0
 	github.com/hibiken/asynq v0.25.1
 	github.com/hibiken/asynq/x v0.0.0-20240506061152-d04888e74845
 	github.com/hibiken/asynqmon v0.7.2
@@ -101,7 +102,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
-	github.com/gophercloud/gophercloud/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/gophercloud/gophercloud/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
 github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
+github.com/gophercloud/gophercloud/v2 v2.4.0 h1:XhP5tVEH3ni66NSNK1+0iSO6kaGPH/6srtx6Cr+8eCg=
+github.com/gophercloud/gophercloud/v2 v2.4.0/go.mod h1:uJWNpTgJPSl2gyzJqcU/pIAhFUWvIkp8eE8M15n9rs4=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/pkg/clients/openstack/block_storage.go
+++ b/pkg/clients/openstack/block_storage.go
@@ -5,8 +5,9 @@
 package openstack
 
 import (
-	"github.com/gardener/inventory/pkg/core/registry"
 	"github.com/gophercloud/gophercloud/v2"
+
+	"github.com/gardener/inventory/pkg/core/registry"
 )
 
 // BlockStorageClientset provides the registry of OpenStack Block Storage API clients

--- a/pkg/clients/openstack/block_storage.go
+++ b/pkg/clients/openstack/block_storage.go
@@ -6,7 +6,7 @@ package openstack
 
 import (
 	"github.com/gardener/inventory/pkg/core/registry"
-    "github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2"
 )
 
 // BlockStorageClientset provides the registry of OpenStack Block Storage API clients

--- a/pkg/clients/openstack/block_storage.go
+++ b/pkg/clients/openstack/block_storage.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"github.com/gardener/inventory/pkg/core/registry"
+    "github.com/gophercloud/gophercloud/v2"
+)
+
+// BlockStorageClientset provides the registry of OpenStack Block Storage API clients
+// for interfacing with block storage resources.
+var BlockStorageClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/client.go
+++ b/pkg/clients/openstack/client.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+// Client is a wrapper for an OpenStack API client, which comes with additional
+// metadata such as the named credentials which were used to create the client,
+// the Project ID, Region and Domain which the client is associated with.
+type Client[T any] struct {
+	// NamedCredentials is the name of the credentials, which were used to
+	// create the API client.
+	NamedCredentials string
+
+	// ProjectID is the project id associated with the client.
+	ProjectID string
+
+	// Region is the region associated with the client.
+	Region string
+
+	// Domain is the domain associated with the client.
+	Domain string
+	// Client is the client used to make API calls to the OpenStack API services.
+	Client T
+}

--- a/pkg/clients/openstack/compute.go
+++ b/pkg/clients/openstack/compute.go
@@ -5,8 +5,9 @@
 package openstack
 
 import (
-	"github.com/gardener/inventory/pkg/core/registry"
 	"github.com/gophercloud/gophercloud/v2"
+
+	"github.com/gardener/inventory/pkg/core/registry"
 )
 
 // ComputeClientset provides the registry of OpenStack Compute API clients

--- a/pkg/clients/openstack/compute.go
+++ b/pkg/clients/openstack/compute.go
@@ -6,7 +6,7 @@ package openstack
 
 import (
 	"github.com/gardener/inventory/pkg/core/registry"
-    "github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2"
 )
 
 // ComputeClientset provides the registry of OpenStack Compute API clients

--- a/pkg/clients/openstack/compute.go
+++ b/pkg/clients/openstack/compute.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"github.com/gardener/inventory/pkg/core/registry"
+    "github.com/gophercloud/gophercloud/v2"
+)
+
+// ComputeClientset provides the registry of OpenStack Compute API clients
+// for interfacing with compute resources (servers, etc).
+var ComputeClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/network.go
+++ b/pkg/clients/openstack/network.go
@@ -5,8 +5,9 @@
 package openstack
 
 import (
-	"github.com/gardener/inventory/pkg/core/registry"
 	"github.com/gophercloud/gophercloud/v2"
+
+	"github.com/gardener/inventory/pkg/core/registry"
 )
 
 // NetworkClientset provides the registry of OpenStack Network API clients

--- a/pkg/clients/openstack/network.go
+++ b/pkg/clients/openstack/network.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"github.com/gardener/inventory/pkg/core/registry"
+    "github.com/gophercloud/gophercloud/v2"
+)
+
+// NetworkClientset provides the registry of OpenStack Network API clients
+// for interfacing with network resoures.
+var NetworkClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/network.go
+++ b/pkg/clients/openstack/network.go
@@ -6,7 +6,7 @@ package openstack
 
 import (
 	"github.com/gardener/inventory/pkg/core/registry"
-    "github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2"
 )
 
 // NetworkClientset provides the registry of OpenStack Network API clients

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -149,9 +149,6 @@ type OpenStackServices struct {
 
 	// BlockStorage provides the Block Storage service configuration.
 	BlockStorage []OpenStackServiceConfig `yaml:"block_storage"`
-
-	// // ObjectStorage provides the Object Storage service configuration.
-	// ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
 }
 
 // OpenStackServiceConfig provides configuration specific for an OpenStack service.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -154,7 +154,7 @@ type OpenStackServices struct {
 // OpenStackServiceConfig provides configuration specific for an OpenStack service.
 type OpenStackServiceConfig struct {
 	// UseCredentials specifies the named credentials to use.
-	UseCredentials string `yaml:"use_credential"`
+	UseCredentials string `yaml:"use_credentials"`
 
 	// Domain specifies the domain to use when initializing the OpenStack client.
 	Domain string `yaml:"domain"`

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -127,80 +127,85 @@ type Config struct {
 }
 
 type OpenStackConfig struct {
-    // IsEnabled specifies whether the OpenStack collection is enabled or not.
-    // Setting this to false will not create any OpenStack client.
-    IsEnabled bool `yaml:"is_enabled"`
+	// IsEnabled specifies whether the OpenStack collection is enabled or not.
+	// Setting this to false will not create any OpenStack client.
+	IsEnabled bool `yaml:"is_enabled"`
 
-    // Services provides the OpenStack service-specific configuration.
-    Services OpenStackServices `yaml:"services"`
+	// Services provides the OpenStack service-specific configuration.
+	Services OpenStackServices `yaml:"services"`
 
-    // Credentials specifies the OpenStack named credentials configuration,
-    // which is used by the various OpenStack services.
-    Credentials map[string]OpenStackCredentialsConfig `yaml:"credentials"`
+	// Credentials specifies the OpenStack named credentials configuration,
+	// which is used by the various OpenStack services.
+	Credentials map[string]OpenStackCredentialsConfig `yaml:"credentials"`
 }
 
 type OpenStackServices struct {
-    // Compute provides the Compute service configuration.
-    Compute []OpenStackServiceConfig `yaml:"compute"`
+	// Compute provides the Compute service configuration.
+	Compute []OpenStackServiceConfig `yaml:"compute"`
 
-    // Network provides the Network service configuration.
-    Network []OpenStackServiceConfig `yaml:"network"`
+	// Network provides the Network service configuration.
+	Network []OpenStackServiceConfig `yaml:"network"`
 
-    // BlockStorage provides the Block Storage service configuration.
-    BlockStorage []OpenStackServiceConfig `yaml:"block_storage"`
+	// BlockStorage provides the Block Storage service configuration.
+	BlockStorage []OpenStackServiceConfig `yaml:"block_storage"`
 
-    // // ObjectStorage provides the Object Storage service configuration.
-    // ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
+	// // ObjectStorage provides the Object Storage service configuration.
+	// ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
 }
 
 type OpenStackServiceConfig struct {
-    // UseCredentials specifies the name of the credentials to use.
-    UseCredentials []string `yaml:"use_credentials"`
+	// UseCredentials specifies the named credentials to use.
+	UseCredentials string `yaml:"use_credential"`
 
-    // Domain specifies the domain to use when initializing the OpenStack client.
-    Domain string `yaml:"domain"`
+	// Domain specifies the domain to use when initializing the OpenStack client.
+	Domain string `yaml:"domain"`
 
-    // Project specifies the project to use when initializing the OpenStack client.
-    Project string `yaml:"project"`
+	// TODO: remove if project_id is enough. Will choose project ID, since it is unique
+	// across realms and can be used as a registry key.
+	// Project specifies the project to use when initializing the OpenStack client.
+	Project string `yaml:"project"`
 
-    // Region specifies the region to use when initializing the OpenStack client.
-    Region string `yaml:"region"`
+	// ProjectID specifies the project ID to use when initializing the OpenStack client.
+	ProjectID string `yaml:"project_id"`
 
-    // AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
-    AuthEndpoint string `yaml:"auth_url"`
+	// Region specifies the region to use when initializing the OpenStack client.
+	Region string `yaml:"region"`
+
+	// AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
+	AuthEndpoint string `yaml:"auth_endpoint"`
 }
 
 type OpenStackCredentialsConfig struct {
-    // Authentication specifies the authentication method/strategy to use
-    // when creating OpenStack API clients. 
-	// The currently supported authentication mechanisms are `user' for username/password 
-    // and `app_credentials'.
-    Authentication string `yaml:"authentication"`
+	// Authentication specifies the authentication method/strategy to use
+	// when creating OpenStack API clients.
+	// The currently supported authentication mechanisms are `user' for username/password
+	// and `app_credentials'.
+	Authentication string `yaml:"authentication"`
 
-    // User provides the settings to use for authentication when using username/password.
-    User OpenStackUserConfig `yaml:"user"`
+	// User provides the settings to use for authentication when using username/password.
+	User OpenStackUserConfig `yaml:"user"`
 
-    // AppCredentials provides the settings to use for authentication when using application credentials.
-    AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
+	// AppCredentials provides the settings to use for authentication when using application credentials.
+	AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
 }
 
 type OpenStackUserConfig struct {
-    // Username specifies the file path of the file containing the username to use.
-    UsernameFile string `yaml:"username_file"`
+	// Username specifies the file path of the file containing the username to use.
+	UsernameFile string `yaml:"username_file"`
 
-    // Username specifies the file path of the file containing the password to use.
-    PasswordFile string `yaml:"password_file"`
+	// Username specifies the file path of the file containing the password to use.
+	PasswordFile string `yaml:"password_file"`
 }
 
 type OpenStackAppCredentialsConfig struct {
-    // AppCredentialsIDFile specifies the file path containing the application credential ID to use when authenticating.
-    AppCredentialsIDFile string `yaml:"app_credentials_id_file"`
+	// AppCredentialsIDFile specifies the file path containing the application credential ID to use when authenticating.
+	AppCredentialsIDFile string `yaml:"app_credentials_id_file"`
 
-    // AppCredentialsSecretFile specifies the file path containing the application credential secret to use when authenticating.
-    AppCredentialsSecretFile string `yaml:"app_credentials_secret_file"`
+	// AppCredentialsSecretFile specifies the file path containing the application credential secret to use when authenticating.
+	AppCredentialsSecretFile string `yaml:"app_credentials_secret_file"`
 
-    // AppCredentialsNameFile specifies the file path containing the application credential name to use when authenticating.
-    AppCredentialsNameFile string `yaml:"app_credentials_name_file"`
+	// AppCredentialsNameFile specifies the file path containing the application credential name to use when authenticating.
+	AppCredentialsNameFile string `yaml:"app_credentials_name_file"`
 }
 
 // AzureConfig provides Azure specific configuration settings.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -190,8 +190,8 @@ type OpenStackCredentialsConfig struct {
 
 // OpenStackPasswordConfig provides the settings to use for authentication when using username/password.
 type OpenStackPasswordConfig struct {
-	// UsernameFile specifies the file path of the file containing the username to use.
-	UsernameFile string `yaml:"username_file"`
+	// Username specifies the username to use.
+	Username string `yaml:"username"`
 
 	// PasswordFile specifies the file path of the file containing the password to use.
 	PasswordFile string `yaml:"password_file"`
@@ -199,14 +199,11 @@ type OpenStackPasswordConfig struct {
 
 // OpenStackAppCredentialsConfig provides the settings to use for authentication when using application credentials.
 type OpenStackAppCredentialsConfig struct {
-	// AppCredentialsIDFile specifies the file path containing the application credential ID to use when authenticating.
-	AppCredentialsIDFile string `yaml:"app_credentials_id_file"`
+	// AppCredentialsID specifies the application credential ID to use when authenticating.
+	AppCredentialsID string `yaml:"app_credentials_id"`
 
 	// AppCredentialsSecretFile specifies the file path containing the application credential secret to use when authenticating.
 	AppCredentialsSecretFile string `yaml:"app_credentials_secret_file"`
-
-	// AppCredentialsNameFile specifies the file path containing the application credential name to use when authenticating.
-	AppCredentialsNameFile string `yaml:"app_credentials_name_file"`
 }
 
 // AzureConfig provides Azure specific configuration settings.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -62,6 +62,14 @@ const (
 	// client, scheduler and workers, when no queue has been specified
 	// explicitly.
 	DefaultQueueName = "default"
+
+	// OpenStackAuthenticationMethodUser is the name of the
+	// authentication mechanism for OpenStack, which uses username/password.
+	OpenStackAuthenticationMethodUser = "user"
+
+	// OpenStackAuthenticationMethodAppCredentials is the name of the
+	// authentication mechanism for OpenStack, which uses application credentials.
+	OpenStackAuthenticationMethodAppCredentials = "app_credentials"
 )
 
 // ErrNoConfigVersion error is returned when the configuration does not specify
@@ -133,63 +141,66 @@ type OpenStackConfig struct {
 
 type OpenStackServices struct {
     // Compute provides the Compute service configuration.
-    Compute OpenStackServiceConfig `yaml:"compute"`
+    Compute []OpenStackServiceConfig `yaml:"compute"`
 
     // Network provides the Network service configuration.
-    Network OpenStackServiceConfig `yaml:"network"`
+    Network []OpenStackServiceConfig `yaml:"network"`
 
     // BlockStorage provides the Block Storage service configuration.
-    BlockStorage OpenStackServiceConfig `yaml:"block_storage"`
+    BlockStorage []OpenStackServiceConfig `yaml:"block_storage"`
 
-    // ObjectStorage provides the Object Storage service configuration.
-    ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
+    // // ObjectStorage provides the Object Storage service configuration.
+    // ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
 }
 
 type OpenStackServiceConfig struct {
     // UseCredentials specifies the name of the credentials to use.
     UseCredentials []string `yaml:"use_credentials"`
 
-    // Region specifies the region to use when initializing the OpenStack client.
-    Region string `yaml:"region"`
-
     // Domain specifies the domain to use when initializing the OpenStack client.
     Domain string `yaml:"domain"`
 
-    // AuthURL specifies the authentication URL to use when initializing the OpenStack client.
-    AuthURL string `yaml:"auth_url"`
+    // Project specifies the project to use when initializing the OpenStack client.
+    Project string `yaml:"project"`
+
+    // Region specifies the region to use when initializing the OpenStack client.
+    Region string `yaml:"region"`
+
+    // AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
+    AuthEndpoint string `yaml:"auth_url"`
 }
 
 type OpenStackCredentialsConfig struct {
     // Authentication specifies the authentication method/strategy to use
     // when creating OpenStack API clients. 
 	// The currently supported authentication mechanisms are `user' for username/password 
-    // and `application_credentials'.
+    // and `app_credentials'.
     Authentication string `yaml:"authentication"`
 
     // User provides the settings to use for authentication when using username/password.
     User OpenStackUserConfig `yaml:"user"`
 
-    // ApplicationCredentials provides the settings to use for authentication when using application credentials.
-    ApplicationCredentials OpenStackApplicationCredentialsConfig `yaml:"application_credentials"`
+    // AppCredentials provides the settings to use for authentication when using application credentials.
+    AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
 }
 
 type OpenStackUserConfig struct {
-    // Username specifies the username to use when authenticating.
-    Username string `yaml:"username"`
+    // Username specifies the file path of the file containing the username to use.
+    UsernameFile string `yaml:"username_file"`
 
-    // Password specifies the password to use when authenticating.
-    Password string `yaml:"password"`
+    // Username specifies the file path of the file containing the password to use.
+    PasswordFile string `yaml:"password_file"`
 }
 
-type OpenStackApplicationCredentialsConfig struct {
-    // ApplicationCredentialsID specifies the application credential ID to use when authenticating.
-    ApplicationCredentialsID string `yaml:"application_credentials_id"`
+type OpenStackAppCredentialsConfig struct {
+    // AppCredentialsIDFile specifies the file path containing the application credential ID to use when authenticating.
+    AppCredentialsIDFile string `yaml:"app_credentials_id_file"`
 
-    // ApplicationCredentialsSecret specifies the application credential secret to use when authenticating.
-    ApplicationCredentialsSecret string `yaml:"application_credentials_secret"`
+    // AppCredentialsSecretFile specifies the file path containing the application credential secret to use when authenticating.
+    AppCredentialsSecretFile string `yaml:"app_credentials_secret_file"`
 
-    // ApplicationCredentialsName specifies the application credential name to use when authenticating.
-    ApplicationCredentialsName string `yaml:"application_credentials_name"`
+    // AppCredentialsNameFile specifies the file path containing the application credential name to use when authenticating.
+    AppCredentialsNameFile string `yaml:"app_credentials_name_file"`
 }
 
 // AzureConfig provides Azure specific configuration settings.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -113,6 +113,83 @@ type Config struct {
 
 	// Azure represents the Azure specific configuration settings.
 	Azure AzureConfig `yaml:"azure"`
+
+	// OpenStack represents the OpenStack specific configuration settings.
+	OpenStack OpenStackConfig `yaml:"openstack"`
+}
+
+type OpenStackConfig struct {
+    // IsEnabled specifies whether the OpenStack collection is enabled or not.
+    // Setting this to false will not create any OpenStack client.
+    IsEnabled bool `yaml:"is_enabled"`
+
+    // Services provides the OpenStack service-specific configuration.
+    Services OpenStackServices `yaml:"services"`
+
+    // Credentials specifies the OpenStack named credentials configuration,
+    // which is used by the various OpenStack services.
+    Credentials map[string]OpenStackCredentialsConfig `yaml:"credentials"`
+}
+
+type OpenStackServices struct {
+    // Compute provides the Compute service configuration.
+    Compute OpenStackServiceConfig `yaml:"compute"`
+
+    // Network provides the Network service configuration.
+    Network OpenStackServiceConfig `yaml:"network"`
+
+    // BlockStorage provides the Block Storage service configuration.
+    BlockStorage OpenStackServiceConfig `yaml:"block_storage"`
+
+    // ObjectStorage provides the Object Storage service configuration.
+    ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
+}
+
+type OpenStackServiceConfig struct {
+    // UseCredentials specifies the name of the credentials to use.
+    UseCredentials []string `yaml:"use_credentials"`
+
+    // Region specifies the region to use when initializing the OpenStack client.
+    Region string `yaml:"region"`
+
+    // Domain specifies the domain to use when initializing the OpenStack client.
+    Domain string `yaml:"domain"`
+
+    // AuthURL specifies the authentication URL to use when initializing the OpenStack client.
+    AuthURL string `yaml:"auth_url"`
+}
+
+type OpenStackCredentialsConfig struct {
+    // Authentication specifies the authentication method/strategy to use
+    // when creating OpenStack API clients. 
+	// The currently supported authentication mechanisms are `user' for username/password 
+    // and `application_credentials'.
+    Authentication string `yaml:"authentication"`
+
+    // User provides the settings to use for authentication when using username/password.
+    User OpenStackUserConfig `yaml:"user"`
+
+    // ApplicationCredentials provides the settings to use for authentication when using application credentials.
+    ApplicationCredentials OpenStackApplicationCredentialsConfig `yaml:"application_credentials"`
+}
+
+type OpenStackUserConfig struct {
+    // Username specifies the username to use when authenticating.
+    Username string `yaml:"username"`
+
+    // Password specifies the password to use when authenticating.
+    Password string `yaml:"password"`
+}
+
+type OpenStackApplicationCredentialsConfig struct {
+    // ApplicationCredentialsID specifies the application credential ID to use when authenticating.
+    ApplicationCredentialsID string `yaml:"application_credentials_id"`
+
+    // ApplicationCredentialsSecret specifies the application credential secret to use when authenticating.
+    ApplicationCredentialsSecret string `yaml:"application_credentials_secret"`
+
+    // ApplicationCredentialsName specifies the application credential name to use when authenticating.
+    ApplicationCredentialsName string `yaml:"application_credentials_name"`
 }
 
 // AzureConfig provides Azure specific configuration settings.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -63,9 +63,9 @@ const (
 	// explicitly.
 	DefaultQueueName = "default"
 
-	// OpenStackAuthenticationMethodUser is the name of the
+	// OpenStackAuthenticationMethodPassword is the name of the
 	// authentication mechanism for OpenStack, which uses username/password.
-	OpenStackAuthenticationMethodUser = "user"
+	OpenStackAuthenticationMethodPassword = "password"
 
 	// OpenStackAuthenticationMethodAppCredentials is the name of the
 	// authentication mechanism for OpenStack, which uses application credentials.
@@ -139,6 +139,7 @@ type OpenStackConfig struct {
 	Credentials map[string]OpenStackCredentialsConfig `yaml:"credentials"`
 }
 
+// OpenStackServices repsesents the known OpenStack services and their config.
 type OpenStackServices struct {
 	// Compute provides the Compute service configuration.
 	Compute []OpenStackServiceConfig `yaml:"compute"`
@@ -153,6 +154,7 @@ type OpenStackServices struct {
 	// ObjectStorage OpenStackServiceConfig `yaml:"object_storage"`
 }
 
+// OpenStackServiceConfig provides configuration specific for an OpenStack service.
 type OpenStackServiceConfig struct {
 	// UseCredentials specifies the named credentials to use.
 	UseCredentials string `yaml:"use_credential"`
@@ -160,8 +162,6 @@ type OpenStackServiceConfig struct {
 	// Domain specifies the domain to use when initializing the OpenStack client.
 	Domain string `yaml:"domain"`
 
-	// TODO: remove if project_id is enough. Will choose project ID, since it is unique
-	// across realms and can be used as a registry key.
 	// Project specifies the project to use when initializing the OpenStack client.
 	Project string `yaml:"project"`
 
@@ -175,28 +175,32 @@ type OpenStackServiceConfig struct {
 	AuthEndpoint string `yaml:"auth_endpoint"`
 }
 
+// OpenStackCredentialsConfig provides named credentials configuration for the OpenStack
+// API clients.
 type OpenStackCredentialsConfig struct {
 	// Authentication specifies the authentication method/strategy to use
 	// when creating OpenStack API clients.
-	// The currently supported authentication mechanisms are `user' for username/password
+	// The currently supported authentication mechanisms are `password' for username/password
 	// and `app_credentials'.
 	Authentication string `yaml:"authentication"`
 
-	// User provides the settings to use for authentication when using username/password.
-	User OpenStackUserConfig `yaml:"user"`
+	// Password provides the settings to use for authentication when using username/password.
+	Password OpenStackPasswordConfig `yaml:"password"`
 
 	// AppCredentials provides the settings to use for authentication when using application credentials.
 	AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
 }
 
-type OpenStackUserConfig struct {
-	// Username specifies the file path of the file containing the username to use.
+// OpenStackPasswordConfig provides the settings to use for authentication when using username/password.
+type OpenStackPasswordConfig struct {
+	// UsernameFile specifies the file path of the file containing the username to use.
 	UsernameFile string `yaml:"username_file"`
 
-	// Username specifies the file path of the file containing the password to use.
+	// PasswordFile specifies the file path of the file containing the password to use.
 	PasswordFile string `yaml:"password_file"`
 }
 
+// OpenStackAppCredentialsConfig provides the settings to use for authentication when using application credentials.
 type OpenStackAppCredentialsConfig struct {
 	// AppCredentialsIDFile specifies the file path containing the application credential ID to use when authenticating.
 	AppCredentialsIDFile string `yaml:"app_credentials_id_file"`

--- a/pkg/openstack/tasks/errors.go
+++ b/pkg/openstack/tasks/errors.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrClientNotFound is an error which is returned when an OpenStack client was not
+// found in the clientset registries.
+var ErrClientNotFound = errors.New("client not found")
+
+// ClientNotFound wraps [ErrClientNotFound] with the given name.
+func ClientNotFound(name string) error {
+	return fmt.Errorf("%w: %s", ErrClientNotFound, name)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces OpenStack to the Inventory.
This includes:
- extending the current configurations with an OpenStackConfig, which contains named credentials and the services that use them
- validating the configuration
- configuring the service clients (compute, networking and block_storage for now). Those are stored in separate registries as usual.

**Special notes for your reviewer**:
The code for the service configurations is identical, so you can skim through the second and third function.
There are file operations for reading the credentials. I haven't extracted those yet, but probably should, tell me what you think about it.

```feature user
OpenStack configuration and clients.
```
