### PR TITLE
feat: add `inventory model query` command

### DIFF
--- a/cmd/inventory/model.go
+++ b/cmd/inventory/model.go
@@ -66,6 +66,10 @@ func NewModelCommand() *cli.Command {
 						Name:  "template",
 						Usage: "template body to render",
 					},
+					&cli.PathFlag{
+						Name:  "template-file",
+						Usage: "template file to render",
+					},
 					&cli.IntFlag{
 						Name:  "limit",
 						Usage: "fetch up to this number of records",
@@ -82,9 +86,23 @@ func NewModelCommand() *cli.Command {
 					return validateDBConfig(conf)
 				},
 				Action: func(ctx *cli.Context) error {
-					templateBody := ctx.String("template")
-					if templateBody == "" {
-						return errNoQueryTemplate
+					var templateBody string
+					templateData := ctx.String("template")
+					templateFile := ctx.Path("template-file")
+
+					switch {
+					case templateData != "" && templateFile != "":
+						return fmt.Errorf("Cannot use --template and --template-file at the same time")
+					case templateData == "" && templateFile == "":
+						return fmt.Errorf("Must specify --template or --template-file")
+					case templateData != "":
+						templateBody = templateData
+					case templateFile != "":
+						data, err := os.ReadFile(templateFile)
+						if err != nil {
+							return err
+						}
+						templateBody = string(data)
 					}
 
 					modelName := ctx.String("model")

--- a/cmd/inventory/model.go
+++ b/cmd/inventory/model.go
@@ -59,26 +59,35 @@ func NewModelCommand() *cli.Command {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "model",
+						Aliases:  []string{"m"},
 						Usage:    "model name to query",
 						Required: true,
 					},
 					&cli.StringFlag{
-						Name:  "template",
-						Usage: "template body to render",
+						Name:    "template",
+						Aliases: []string{"t"},
+						Usage:   "template body to render",
 					},
 					&cli.PathFlag{
 						Name:  "template-file",
 						Usage: "template file to render",
 					},
 					&cli.IntFlag{
-						Name:  "limit",
-						Usage: "fetch up to this number of records",
-						Value: 0,
+						Name:    "limit",
+						Aliases: []string{"l"},
+						Usage:   "fetch up to this number of records",
+						Value:   0,
 					},
 					&cli.IntFlag{
-						Name:  "offset",
-						Usage: "fetch records starting from this offset",
-						Value: 0,
+						Name:    "offset",
+						Aliases: []string{"o"},
+						Usage:   "fetch records starting from this offset",
+						Value:   0,
+					},
+					&cli.StringSliceFlag{
+						Name:    "relation",
+						Aliases: []string{"r"},
+						Usage:   "relationship to load for the model",
 					},
 				},
 				Before: func(ctx *cli.Context) error {
@@ -137,13 +146,24 @@ func NewModelCommand() *cli.Command {
 					// Prepare options to apply to the base query
 					type queryOpt func(q *bun.SelectQuery) *bun.SelectQuery
 					opts := make([]queryOpt, 0)
+
+					// Offset option
 					opts = append(opts, func(q *bun.SelectQuery) *bun.SelectQuery {
 						return q.Offset(offset)
 					})
 
+					// Limit option
 					if limit > 0 {
 						opts = append(opts, func(q *bun.SelectQuery) *bun.SelectQuery {
 							return q.Limit(limit)
+						})
+					}
+
+					// Relationship options
+					relationships := ctx.StringSlice("relation")
+					for _, relation := range relationships {
+						opts = append(opts, func(q *bun.SelectQuery) *bun.SelectQuery {
+							return q.Relation(relation)
 						})
 					}
 

--- a/cmd/inventory/model.go
+++ b/cmd/inventory/model.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -17,10 +16,6 @@ import (
 
 	"github.com/gardener/inventory/pkg/core/registry"
 )
-
-// errNoQueryTemplate is an error which is returned by the query sub-command,
-// when an expected [text/template] body was not specified.
-var errNoQueryTemplate = errors.New("no query template specified")
 
 // NewModelCommand returns a new command for interfacing with the models.
 func NewModelCommand() *cli.Command {

--- a/docs/db-queries.md
+++ b/docs/db-queries.md
@@ -1,7 +1,11 @@
 # Querying the Database
 
-The following section provides some sample queries you can use with the data
-collected by the Inventory system.
+The following document provides example SQL queries, which you can run against
+the data collected by the Inventory system.
+
+For querying data via the `inventory` CLI tool, please refer to the [Querying
+Models](./ops-guide.md#querying-models) section from the [Operations
+Guide](./ops-guide.md).
 
 ## AWS VPCs Per Region
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new command for querying data via the CLI tool - `inventory model query`

The command allows fetching of data for a given model by looking up the registry of existing models and constructing a query to be executed against the database.

After the data has been loaded it is passed to a `text/template` template for further transformation of the data.

Please refer to the Ops Guide for more details about the supported options and example usage.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: introduce `inventory model query` command
```
