### PR TITLE
feat: add support for running external commands

### DIFF
--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -79,9 +79,10 @@ func NewTaskCommand() *cli.Command {
 						Required: true,
 					},
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -99,19 +100,22 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"a"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"p"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -124,19 +128,22 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"p"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"p"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -149,19 +156,22 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"ar"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"p"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -173,19 +183,22 @@ func NewTaskCommand() *cli.Command {
 				Usage: "list completed tasks",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"q"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -198,19 +211,22 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"r"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"p"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -223,19 +239,22 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"s"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.IntFlag{
-						Name:  "page",
-						Usage: "page number to retrieve",
-						Value: 1,
+						Name:    "page",
+						Aliases: []string{"p"},
+						Usage:   "page number to retrieve",
+						Value:   1,
 					},
 					&cli.IntFlag{
-						Name:  "size",
-						Usage: "page size to use",
-						Value: 50,
+						Name:    "size",
+						Aliases: []string{"s"},
+						Usage:   "page size to use",
+						Value:   50,
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -249,6 +268,7 @@ func NewTaskCommand() *cli.Command {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     "task",
+						Aliases:  []string{"t"},
 						Usage:    "name of task to enqueue",
 						Required: true,
 					},
@@ -261,9 +281,10 @@ func NewTaskCommand() *cli.Command {
 						Usage: "path to a payload file",
 					},
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 				},
 				Action: func(ctx *cli.Context) error {
@@ -311,9 +332,10 @@ func NewTaskCommand() *cli.Command {
 				Aliases: []string{"i"},
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:  "queue",
-						Usage: "name of queue to use",
-						Value: "default",
+						Name:    "queue",
+						Aliases: []string{"q"},
+						Usage:   "name of queue to use",
+						Value:   "default",
 					},
 					&cli.StringFlag{
 						Name:     "id",

--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -191,7 +191,7 @@ func NewTaskCommand() *cli.Command {
 					},
 					&cli.IntFlag{
 						Name:    "page",
-						Aliases: []string{"q"},
+						Aliases: []string{"p"},
 						Usage:   "page number to retrieve",
 						Value:   1,
 					},

--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -254,6 +254,10 @@ func NewTaskCommand() *cli.Command {
 					},
 					&cli.StringFlag{
 						Name:  "payload",
+						Usage: "task payload",
+					},
+					&cli.PathFlag{
+						Name:  "payload-file",
 						Usage: "path to a payload file",
 					},
 					&cli.StringFlag{
@@ -269,7 +273,6 @@ func NewTaskCommand() *cli.Command {
 
 					taskName := ctx.String("task")
 					queue := ctx.String("queue")
-					payloadFile := ctx.String("payload")
 
 					_, ok := registry.TaskRegistry.Get(taskName)
 					if !ok {
@@ -277,7 +280,14 @@ func NewTaskCommand() *cli.Command {
 					}
 
 					var payload []byte
-					if payloadFile != "" {
+					payloadData := ctx.String("payload")
+					payloadFile := ctx.Path("payload-file")
+					switch {
+					case payloadData != "" && payloadFile != "":
+						return fmt.Errorf("Cannot use --payload and --payload-file at the same time")
+					case payloadData != "":
+						payload = []byte(payloadData)
+					case payloadFile != "":
 						data, err := os.ReadFile(payloadFile)
 						if err != nil {
 							return fmt.Errorf("Cannot read payload file: %w", err)

--- a/pkg/common/tasks/command.go
+++ b/pkg/common/tasks/command.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+// ErrNoCommand is an error which is returned when the task for executing
+// external commands was called without specifying a command as part of the
+// payload.
+var ErrNoCommand = errors.New("no command specified")
+
+const (
+	// CommandTaskType is the name of the task for executing external
+	// commands.
+	CommandTaskType = "common:task:command"
+)
+
+// CommandPayload represents the payload of the task for executing external
+// commands.
+type CommandPayload struct {
+	// Command specifies the path to the command to be executed
+	Command string `yaml:"command" json:"command"`
+
+	// Args specifies any optional arguments to be passed to the command.
+	Args []string `yaml:"args" json:"args"`
+
+	// Dir specifies the working directory of the command. If not specified
+	// then the external command will be executed in the calling process'
+	// current directory.
+	Dir string `yaml:"dir" json:"dir"`
+}
+
+// HandleCommandTask executes the command specified as part of the payload.
+func HandleCommandTask(ctx context.Context, task *asynq.Task) error {
+	data := task.Payload()
+	var payload CommandPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if payload.Command == "" {
+		return asynqutils.SkipRetry(ErrNoCommand)
+	}
+
+	path, err := exec.LookPath(payload.Command)
+	if err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	logger := asynqutils.GetLogger(ctx)
+	logger.Info(
+		"executing command",
+		"command", path,
+		"args", payload.Args,
+		"dir", payload.Dir,
+	)
+
+	cmd := exec.CommandContext(ctx, path, payload.Args...)
+	cmd.Dir = payload.Dir
+
+	return cmd.Run()
+}
+
+func init() {
+	registry.TaskRegistry.MustRegister(CommandTaskType, asynq.HandlerFunc(HandleCommandTask))
+}

--- a/pkg/common/tasks/housekeeper.go
+++ b/pkg/common/tasks/housekeeper.go
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"time"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/gardener/inventory/pkg/clients/db"
+	"github.com/gardener/inventory/pkg/core/registry"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// HousekeeperTaskType is the name of the task responsible for cleaning
+	// up stale records from the database.
+	HousekeeperTaskType = "common:task:housekeeper"
+)
+
+// HousekeeperPayload represents the payload of the housekeeper task.
+type HousekeeperPayload struct {
+	// Retention provides the retention configuration of objects.
+	Retention []RetentionConfig `yaml:"retention" json:"retention"`
+}
+
+// RetentionConfig represents the retention configuration for a given model.
+type RetentionConfig struct {
+	// Name specifies the model name.
+	Name string `yaml:"name" json:"name"`
+
+	// Duration specifies the max duration for which an object will be kept,
+	// if it hasn't been updated recently.
+	//
+	// For example:
+	//
+	// UpdatedAt field for an object is set to: Thu May 30 16:00:00 EEST 2024
+	// Duration of the object is configured to: 4 hours
+	//
+	// If the object is not update anymore by the time the housekeeper runs,
+	// after 20:00:00 this object will be considered as stale and removed
+	// from the database.
+	Duration time.Duration `yaml:"duration" json:"duration"`
+}
+
+// HandleHousekeeperTask performs housekeeping activities, such as deleting
+// stale records.
+func HandleHousekeeperTask(ctx context.Context, task *asynq.Task) error {
+	var payload HousekeeperPayload
+	if err := asynqutils.Unmarshal(task.Payload(), &payload); err != nil {
+		return err
+	}
+
+	logger := asynqutils.GetLogger(ctx)
+	for _, item := range payload.Retention {
+		// Look up the registry for the actual model type
+		model, ok := registry.ModelRegistry.Get(item.Name)
+		if !ok {
+			logger.Warn("model not found in registry", "name", item.Name)
+			continue
+		}
+
+		now := time.Now()
+		past := now.Add(-item.Duration)
+		out, err := db.DB.NewDelete().
+			Model(model).
+			Where("date_part('epoch', updated_at) < ?", past.Unix()).
+			Exec(ctx)
+
+		switch err {
+		case nil:
+			count, err := out.RowsAffected()
+			if err != nil {
+				logger.Error("failed to get number of deleted rows", "name", item.Name, "reason", err)
+				continue
+			}
+			logger.Info("deleted stale records", "name", item.Name, "count", count)
+		default:
+			// Simply log the error here and keep going with the
+			// rest of the objects to cleanup
+			logger.Error("failed to delete stale records", "name", item.Name, "reason", err)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	registry.TaskRegistry.MustRegister(HousekeeperTaskType, asynq.HandlerFunc(HandleHousekeeperTask))
+}

--- a/pkg/common/tasks/housekeeper.go
+++ b/pkg/common/tasks/housekeeper.go
@@ -51,7 +51,7 @@ type RetentionConfig struct {
 func HandleHousekeeperTask(ctx context.Context, task *asynq.Task) error {
 	var payload HousekeeperPayload
 	if err := asynqutils.Unmarshal(task.Payload(), &payload); err != nil {
-		return err
+		return asynqutils.SkipRetry(err)
 	}
 
 	logger := asynqutils.GetLogger(ctx)

--- a/pkg/common/tasks/queue_mgmt.go
+++ b/pkg/common/tasks/queue_mgmt.go
@@ -45,7 +45,7 @@ func HandleDeleteArchivedTask(ctx context.Context, task *asynq.Task) error {
 
 	count, err := asynqclient.Inspector.DeleteAllArchivedTasks(payload.Queue)
 	if err != nil {
-		logger.Error("failed to delete archived tasks", "queue", payload.Queue, "reason", err)
+		return err
 	}
 
 	logger.Info("deleted archived tasks", "count", count)
@@ -68,7 +68,7 @@ func HandleDeleteCompletedTask(ctx context.Context, task *asynq.Task) error {
 
 	count, err := asynqclient.Inspector.DeleteAllCompletedTasks(payload.Queue)
 	if err != nil {
-		logger.Error("failed to delete completed tasks", "queue", payload.Queue, "reason", err)
+		return err
 	}
 
 	logger.Info("deleted completed tasks", "count", count)

--- a/pkg/common/tasks/queue_mgmt.go
+++ b/pkg/common/tasks/queue_mgmt.go
@@ -7,20 +7,15 @@ package tasks
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/hibiken/asynq"
 
 	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
-	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/core/registry"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
 const (
-	// HousekeeperTaskType is the name of the task responsible for cleaning
-	// up stale records from the database.
-	HousekeeperTaskType = "common:task:housekeeper"
 	// DeleteArchivedTaskType is the name of the task responsible for deleting
 	// archived tasks from a task queue
 	DeleteArchivedTaskType = "common:task:delete-archived-tasks"
@@ -29,77 +24,10 @@ const (
 	DeleteCompletedTaskType = "common:task:delete-completed-tasks"
 )
 
-// HousekeeperPayload represents the payload of the housekeeper task.
-type HousekeeperPayload struct {
-	// Retention provides the retention configuration of objects.
-	Retention []RetentionConfig `yaml:"retention" json:"retention"`
-}
-
 // DeleteQueuePayload represents the payload of a task management task.
 type DeleteQueuePayload struct {
 	// Name of the queue that holds the tasks.
 	Queue string `yaml:"queue" json:"queue"`
-}
-
-// RetentionConfig represents the retention configuration for a given model.
-type RetentionConfig struct {
-	// Name specifies the model name.
-	Name string `yaml:"name" json:"name"`
-
-	// Duration specifies the max duration for which an object will be kept,
-	// if it hasn't been updated recently.
-	//
-	// For example:
-	//
-	// UpdatedAt field for an object is set to: Thu May 30 16:00:00 EEST 2024
-	// Duration of the object is configured to: 4 hours
-	//
-	// If the object is not update anymore by the time the housekeeper runs,
-	// after 20:00:00 this object will be considered as stale and removed
-	// from the database.
-	Duration time.Duration `yaml:"duration" json:"duration"`
-}
-
-// HandleHousekeeperTask performs housekeeping activities, such as deleting
-// stale records.
-func HandleHousekeeperTask(ctx context.Context, task *asynq.Task) error {
-	var payload HousekeeperPayload
-	if err := asynqutils.Unmarshal(task.Payload(), &payload); err != nil {
-		return err
-	}
-
-	logger := asynqutils.GetLogger(ctx)
-	for _, item := range payload.Retention {
-		// Look up the registry for the actual model type
-		model, ok := registry.ModelRegistry.Get(item.Name)
-		if !ok {
-			logger.Warn("model not found in registry", "name", item.Name)
-			continue
-		}
-
-		now := time.Now()
-		past := now.Add(-item.Duration)
-		out, err := db.DB.NewDelete().
-			Model(model).
-			Where("date_part('epoch', updated_at) < ?", past.Unix()).
-			Exec(ctx)
-
-		switch err {
-		case nil:
-			count, err := out.RowsAffected()
-			if err != nil {
-				logger.Error("failed to get number of deleted rows", "name", item.Name, "reason", err)
-				continue
-			}
-			logger.Info("deleted stale records", "name", item.Name, "count", count)
-		default:
-			// Simply log the error here and keep going with the
-			// rest of the objects to cleanup
-			logger.Error("failed to delete stale records", "name", item.Name, "reason", err)
-		}
-	}
-
-	return nil
 }
 
 // HandleDeleteArchivedTask deletes archived tasks.
@@ -149,7 +77,6 @@ func HandleDeleteCompletedTask(ctx context.Context, task *asynq.Task) error {
 }
 
 func init() {
-	registry.TaskRegistry.MustRegister(HousekeeperTaskType, asynq.HandlerFunc(HandleHousekeeperTask))
 	registry.TaskRegistry.MustRegister(DeleteArchivedTaskType, asynq.HandlerFunc(HandleDeleteArchivedTask))
 	registry.TaskRegistry.MustRegister(DeleteCompletedTaskType, asynq.HandlerFunc(HandleDeleteCompletedTask))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new task for running external commands - `common:task:payload`.

Also:

- Added short option names for the various `queue`, `page` and `size` options of `inventory task` sub-commands
- Re-organized the package of common tasks into separate files

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added new task for running external commands - `common:task:command`
```
