### PR TITLE
OpenStack models and tasks

### DIFF
--- a/cmd/inventory/init.go
+++ b/cmd/inventory/init.go
@@ -14,4 +14,6 @@ import (
 	_ "github.com/gardener/inventory/pkg/gardener/tasks"
 	_ "github.com/gardener/inventory/pkg/gcp/models"
 	_ "github.com/gardener/inventory/pkg/gcp/tasks"
+	_ "github.com/gardener/inventory/pkg/openstack/models"
+	_ "github.com/gardener/inventory/pkg/openstack/tasks"
 )

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
-	github.com/gophercloud/gophercloud/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/gophercloud/gophercloud/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package models
+
+func init() {
+	// Register the models with the default registry
+}

--- a/pkg/openstack/tasks/tasks.go
+++ b/pkg/openstack/tasks/tasks.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/gardener/inventory/pkg/clients/db"
+	"github.com/gardener/inventory/pkg/common/utils"
+	"github.com/gardener/inventory/pkg/core/registry"
+)
+
+const (
+	// TaskCollectAll is a meta task, which enqueues all relevant OpenStack
+	// tasks.
+	TaskCollectAll = "openstack:task:collect-all"
+
+	// TaskLinkAll is a task, which creates links between the OpenStack
+	// models.
+	TaskLinkAll = "openstack:task:link-all"
+)
+
+// HandleCollectAllTask is a handler, which enqueues tasks for collecting all
+// OpenStack objects.
+func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
+	// Task constructors
+	taskFns := []utils.TaskConstructor{
+	}
+
+	return utils.Enqueue(ctx, taskFns)
+}
+
+// HandleLinkAllTask is a handler, which establishes links between the various
+// OpenStack models.
+func HandleLinkAllTask(ctx context.Context, t *asynq.Task) error {
+	linkFns := []utils.LinkFunction{
+	}
+
+	return utils.LinkObjects(ctx, db.DB, linkFns)
+}
+
+// init registers our task handlers and periodic tasks with the registries.
+func init() {
+	// Task handlers
+	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
+	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds boilerplate around OpenStack models and tasks packages.
The PR is separated, so PRs for task collection don't reintroduce the same files as the ones here.