### PR TITLE
feat: export some utility code for re-use

### DIFF
--- a/cmd/inventory/dashboard.go
+++ b/cmd/inventory/dashboard.go
@@ -28,7 +28,6 @@ func NewDashboardCommand() *cli.Command {
 		Before: func(ctx *cli.Context) error {
 			conf := getConfig(ctx)
 			validatorFuncs := []func(c *config.Config) error{
-				validateRedisConfig,
 				validateDashboardConfig,
 			}
 

--- a/cmd/inventory/database.go
+++ b/cmd/inventory/database.go
@@ -23,10 +23,6 @@ func NewDatabaseCommand() *cli.Command {
 		Name:    "database",
 		Usage:   "database operations",
 		Aliases: []string{"db"},
-		Before: func(ctx *cli.Context) error {
-			conf := getConfig(ctx)
-			return validateDBConfig(conf)
-		},
 		Subcommands: []*cli.Command{
 			{
 				Name:    "init",
@@ -34,7 +30,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"i"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -54,7 +53,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"m"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -91,7 +93,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"r"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -129,7 +134,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"l"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -145,7 +153,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"u"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -160,7 +171,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"c"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -190,7 +204,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"s"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -223,7 +240,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"a"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {
@@ -252,7 +272,10 @@ func NewDatabaseCommand() *cli.Command {
 				Aliases: []string{"p"},
 				Action: func(ctx *cli.Context) error {
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 					migrator, err := newMigrator(conf, db)
 					if err != nil {

--- a/cmd/inventory/main.go
+++ b/cmd/inventory/main.go
@@ -48,8 +48,8 @@ func main() {
 			},
 		},
 		Before: func(ctx *cli.Context) error {
-			configFile := ctx.StringSlice("config")
-			conf, err := config.Parse(configFile)
+			configPaths := ctx.StringSlice("config")
+			conf, err := config.Parse(configPaths...)
 			if err != nil {
 				return fmt.Errorf("Cannot parse config: %w", err)
 			}

--- a/cmd/inventory/model.go
+++ b/cmd/inventory/model.go
@@ -85,10 +85,6 @@ func NewModelCommand() *cli.Command {
 						Usage:   "relationship to load for the model",
 					},
 				},
-				Before: func(ctx *cli.Context) error {
-					conf := getConfig(ctx)
-					return validateDBConfig(conf)
-				},
 				Action: func(ctx *cli.Context) error {
 					var templateBody string
 					templateData := ctx.String("template")
@@ -126,7 +122,10 @@ func NewModelCommand() *cli.Command {
 
 					// Configure database connection
 					conf := getConfig(ctx)
-					db := newDB(conf)
+					db, err := newDB(conf)
+					if err != nil {
+						return err
+					}
 					defer db.Close()
 
 					// Create a new slice of the type we have in the registry

--- a/cmd/inventory/queue.go
+++ b/cmd/inventory/queue.go
@@ -17,10 +17,6 @@ func NewQueueCommand() *cli.Command {
 		Name:    "queue",
 		Usage:   "queue operations",
 		Aliases: []string{"q"},
-		Before: func(ctx *cli.Context) error {
-			conf := getConfig(ctx)
-			return validateRedisConfig(conf)
-		},
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",

--- a/cmd/inventory/scheduler.go
+++ b/cmd/inventory/scheduler.go
@@ -23,10 +23,6 @@ func NewSchedulerCommand() *cli.Command {
 		Name:    "scheduler",
 		Usage:   "scheduler operations",
 		Aliases: []string{"s"},
-		Before: func(ctx *cli.Context) error {
-			conf := getConfig(ctx)
-			return validateRedisConfig(conf)
-		},
 		Subcommands: []*cli.Command{
 			{
 				Name:    "start",

--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -22,10 +22,6 @@ func NewTaskCommand() *cli.Command {
 		Name:    "task",
 		Usage:   "task operations",
 		Aliases: []string{"t"},
-		Before: func(ctx *cli.Context) error {
-			conf := getConfig(ctx)
-			return validateRedisConfig(conf)
-		},
 		Subcommands: []*cli.Command{
 			{
 				Name:    "list",

--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -205,7 +205,7 @@ func newInspector(conf *config.Config) *asynq.Inspector {
 }
 
 // newWorker creates a new [workerutils.Worker] from the given config.
-func newWorker(conf *config.Config) (*workerutils.Worker, error) {
+func newWorker(conf *config.Config) *workerutils.Worker {
 	redisClientOpt := newRedisClientOpt(conf)
 	opts := make([]workerutils.Option, 0)
 	logLevel := asynq.InfoLevel
@@ -218,18 +218,13 @@ func newWorker(conf *config.Config) (*workerutils.Worker, error) {
 	worker := workerutils.NewFromConfig(redisClientOpt, conf.Worker, opts...)
 
 	// Configure middlewares
-	logger, err := newLogger(os.Stdout, conf)
-	if err != nil {
-		return nil, err
-	}
-
 	middlewares := []asynq.MiddlewareFunc{
-		asynqutils.NewLoggerMiddleware(logger),
+		asynqutils.NewLoggerMiddleware(slog.Default()),
 		asynqutils.NewMeasuringMiddleware(),
 	}
 	worker.UseMiddlewares(middlewares...)
 
-	return worker, nil
+	return worker
 }
 
 // newDB returns a new [bun.DB] database from the given config.

--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -190,12 +190,7 @@ func newLogger(w io.Writer, conf *config.Config) (*slog.Logger, error) {
 
 // newRedisClientOpt returns a new [asynq.RedisClientOpt] from the given config.
 func newRedisClientOpt(conf *config.Config) asynq.RedisClientOpt {
-	// TODO: Handle authentication, TLS, etc.
-	opts := asynq.RedisClientOpt{
-		Addr: conf.Redis.Endpoint,
-	}
-
-	return opts
+	return asynqutils.NewRedisClientOptFromConfig(conf.Redis)
 }
 
 // newAsynqClient creates a new [asynq.Client] from the given config

--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -17,8 +16,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/olekukonko/tablewriter"
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/dialect/pgdialect"
-	"github.com/uptrace/bun/driver/pgdriver"
 	"github.com/uptrace/bun/extra/bundebug"
 	"github.com/uptrace/bun/migrate"
 	"github.com/urfave/cli/v2"
@@ -27,6 +24,7 @@ import (
 	"github.com/gardener/inventory/pkg/core/config"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 	workerutils "github.com/gardener/inventory/pkg/utils/asynq/worker"
+	dbutils "github.com/gardener/inventory/pkg/utils/db"
 )
 
 // na is the const used to represent N/A values
@@ -236,8 +234,7 @@ func newWorker(conf *config.Config) (*workerutils.Worker, error) {
 
 // newDB returns a new [bun.DB] database from the given config.
 func newDB(conf *config.Config) *bun.DB {
-	pgdb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(conf.Database.DSN)))
-	db := bun.NewDB(pgdb, pgdialect.New())
+	db := dbutils.NewFromConfig(conf.Database)
 	db.AddQueryHook(bundebug.NewQueryHook(bundebug.WithVerbose(conf.Debug)))
 
 	return db

--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -153,11 +153,7 @@ func NewWorkerCommand() *cli.Command {
 					defer client.Close()
 					inspector := newInspector(conf)
 					defer inspector.Close()
-
-					worker, err := newWorker(conf)
-					if err != nil {
-						return err
-					}
+					worker := newWorker(conf)
 
 					// Gardener client configs
 					if err := configureGardenerClient(ctx.Context, conf); err != nil {

--- a/pkg/clients/asynq/asynq.go
+++ b/pkg/clients/asynq/asynq.go
@@ -4,9 +4,14 @@
 
 package asynq
 
-import "github.com/hibiken/asynq"
+import (
+	"github.com/hibiken/asynq"
+)
 
+// Client is the [asynq.Client] used by workers during runtime.
 var Client *asynq.Client
+
+// Inspector is the [asynq.Inspector] used by workers during runtime.
 var Inspector *asynq.Inspector
 
 // SetClient shall be invoked from cli commands to set the asynq client for the workers.

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -678,7 +678,7 @@ func ParseFileInto(path string, out any) error {
 // Parse parses the configs from the given paths in-order. Configuration
 // settings provided later in the sequence of paths will override settings from
 // previous config paths.
-func Parse(paths []string) (*Config, error) {
+func Parse(paths ...string) (*Config, error) {
 	var conf Config
 
 	for _, path := range paths {
@@ -705,8 +705,8 @@ func Parse(paths []string) (*Config, error) {
 
 // MustParse parses the configs from the given paths, or panics in case of
 // errors.
-func MustParse(paths []string) *Config {
-	config, err := Parse(paths)
+func MustParse(paths ...string) *Config {
+	config, err := Parse(paths...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"runtime"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -694,11 +693,6 @@ func Parse(paths []string) (*Config, error) {
 		if conf.Version != ConfigFormatVersion {
 			return nil, fmt.Errorf("%w: %s (%s)", ErrUnsupportedVersion, conf.Version, path)
 		}
-	}
-
-	// Worker defaults
-	if conf.Worker.Concurrency <= 0 {
-		conf.Worker.Concurrency = runtime.NumCPU()
 	}
 
 	// AWS defaults

--- a/pkg/utils/asynq/asynq.go
+++ b/pkg/utils/asynq/asynq.go
@@ -137,3 +137,14 @@ func GetQueueName(ctx context.Context) string {
 
 	return config.DefaultQueueName
 }
+
+// NewRedisClientOptFromConfig returns an [asynq.RedisClientOpt] from the
+// provided [config.RedisConfig] configuration.
+func NewRedisClientOptFromConfig(conf config.RedisConfig) asynq.RedisClientOpt {
+	// TODO: Handle authentication, TLS, etc.
+	opts := asynq.RedisClientOpt{
+		Addr: conf.Endpoint,
+	}
+
+	return opts
+}

--- a/pkg/utils/asynq/worker/worker.go
+++ b/pkg/utils/asynq/worker/worker.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package worker
+
+import (
+	"runtime"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/gardener/inventory/pkg/core/config"
+)
+
+// Option is a function, which configures the [Worker].
+type Option func(conf *asynq.Config)
+
+// Worker wraps an [asynq.Server] and [asynq.ServeMux] with additional
+// convenience methods for task handlers.
+type Worker struct {
+	server *asynq.Server
+	mux    *asynq.ServeMux
+}
+
+// NewFromConfig creates a new [Worker] based on the provided
+// [config.WorkerConfig] spec.
+func NewFromConfig(r asynq.RedisClientOpt, conf config.WorkerConfig, opts ...Option) *Worker {
+	concurrency := conf.Concurrency
+	if concurrency <= 0 {
+		concurrency = runtime.NumCPU()
+	}
+
+	defaultQueues := map[string]int{
+		config.DefaultQueueName: 1,
+	}
+
+	queues := conf.Queues
+	if len(queues) == 0 {
+		queues = defaultQueues
+	}
+
+	config := asynq.Config{
+		Concurrency:    concurrency,
+		Queues:         queues,
+		StrictPriority: conf.StrictPriority,
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	server := asynq.NewServer(r, config)
+	mux := asynq.NewServeMux()
+	worker := &Worker{
+		server: server,
+		mux:    mux,
+	}
+
+	return worker
+}

--- a/pkg/utils/asynq/worker/worker.go
+++ b/pkg/utils/asynq/worker/worker.go
@@ -22,6 +22,25 @@ type Worker struct {
 	mux    *asynq.ServeMux
 }
 
+// WithLogLevel is an [Option], which configures the log level of the [Worker].
+func WithLogLevel(level asynq.LogLevel) Option {
+	opt := func(conf *asynq.Config) {
+		conf.LogLevel = level
+	}
+
+	return opt
+}
+
+// WithErrorHandler is an [Option], which configures the [Worker] to use the
+// specified [asynq.ErrorHandler].
+func WithErrorHandler(handler asynq.ErrorHandler) Option {
+	opt := func(conf *asynq.Config) {
+		conf.ErrorHandler = handler
+	}
+
+	return opt
+}
+
 // NewFromConfig creates a new [Worker] based on the provided
 // [config.WorkerConfig] spec.
 func NewFromConfig(r asynq.RedisClientOpt, conf config.WorkerConfig, opts ...Option) *Worker {

--- a/pkg/utils/asynq/worker/worker.go
+++ b/pkg/utils/asynq/worker/worker.go
@@ -98,3 +98,14 @@ func (w *Worker) HandlersFromRegistry(reg *registry.Registry[string, asynq.Handl
 		return nil
 	})
 }
+
+// Run starts the task processing by calling [asynq.Server.Start] and blocks
+// until an OS signal is received.
+func (w *Worker) Run() error {
+	return w.server.Run(w.mux)
+}
+
+// Shutdown gracefully shuts down the server by calling [asynq.Server.Shutdown].
+func (w *Worker) Shutdown() {
+	w.server.Shutdown()
+}

--- a/pkg/utils/asynq/worker/worker.go
+++ b/pkg/utils/asynq/worker/worker.go
@@ -77,3 +77,9 @@ func NewFromConfig(r asynq.RedisClientOpt, conf config.WorkerConfig, opts ...Opt
 
 	return worker
 }
+
+// UseMiddlewares configures the [Worker] multiplexer to use the specified
+// [asynq.MiddlewareFunc]
+func (w *Worker) UseMiddlewares(middlewares ...asynq.MiddlewareFunc) {
+	w.mux.Use(middlewares...)
+}

--- a/pkg/utils/asynq/worker/worker.go
+++ b/pkg/utils/asynq/worker/worker.go
@@ -93,7 +93,7 @@ func (w *Worker) Handle(pattern string, handler asynq.Handler) {
 // HandlersFromRegistry registers task handlers with the [Worker] multiplexer
 // using the given registry.
 func (w *Worker) HandlersFromRegistry(reg *registry.Registry[string, asynq.Handler]) {
-	reg.Range(func(pattern string, handler asynq.Handler) error {
+	_ = reg.Range(func(pattern string, handler asynq.Handler) error {
 		w.Handle(pattern, handler)
 		return nil
 	})

--- a/pkg/utils/db/db.go
+++ b/pkg/utils/db/db.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
@@ -14,11 +15,19 @@ import (
 	"github.com/gardener/inventory/pkg/core/config"
 )
 
+// ErrInvalidDSN error is returned, when the DSN configuration is incorrect, or
+// empty.
+var ErrInvalidDSN = errors.New("invalid or missing database configuration")
+
 // NewFromConfig creates a new [bun.DB] based on the provided
 // [config.DatabaseConfig] spec.
-func NewFromConfig(conf config.DatabaseConfig) *bun.DB {
+func NewFromConfig(conf config.DatabaseConfig) (*bun.DB, error) {
+	if conf.DSN == "" {
+		return nil, ErrInvalidDSN
+	}
+
 	pgdb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(conf.DSN)))
 	db := bun.NewDB(pgdb, pgdialect.New())
 
-	return db
+	return db, nil
 }

--- a/pkg/utils/db/db.go
+++ b/pkg/utils/db/db.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package db
+
+import (
+	"database/sql"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+	"github.com/uptrace/bun/driver/pgdriver"
+
+	"github.com/gardener/inventory/pkg/core/config"
+)
+
+// NewFromConfig creates a new [bun.DB] based on the provided
+// [config.DatabaseConfig] spec.
+func NewFromConfig(conf config.DatabaseConfig) *bun.DB {
+	pgdb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(conf.DSN)))
+	db := bun.NewDB(pgdb, pgdialect.New())
+
+	return db
+}

--- a/pkg/utils/slog/slog.go
+++ b/pkg/utils/slog/slog.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package slog
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/gardener/inventory/pkg/core/config"
+)
+
+// ErrInvalidLogLevel is an error, which is returned when an invalid log level
+// has been configured.
+var ErrInvalidLogLevel = errors.New("invalid log level")
+
+// ErrInvalidLogFormat is an error, which is returned when an invalid log format
+// has been configured.
+var ErrInvalidLogFormat = errors.New("invalid log format")
+
+// LogLevel represents the log level.
+type LogLevel string
+
+var (
+	// The supported log levels
+	LevelInfo  LogLevel = "info"
+	LevelWarn  LogLevel = "warn"
+	LevelError LogLevel = "error"
+	LevelDebug LogLevel = "debug"
+)
+
+// LogFormat represents the format of log events.
+type LogFormat string
+
+var (
+	FormatText LogFormat = "text"
+	FormatJSON LogFormat = "json"
+)
+
+// NewFromConfig creates a new [slog.Logger] based on the provided
+// [config.LoggingConfig] spec. The returned logger outputs to the given
+// [io.Writer].
+func NewFromConfig(w io.Writer, conf config.LoggingConfig) (*slog.Logger, error) {
+	// Defaults, if we don't have any logging settings
+	logLevel := LevelInfo
+	logFormat := FormatText
+
+	if conf.Level != "" {
+		logLevel = LogLevel(conf.Level)
+	}
+
+	if conf.Format != "" {
+		logFormat = LogFormat(conf.Format)
+	}
+
+	// Supported log levels
+	levels := map[LogLevel]slog.Level{
+		LevelInfo:  slog.LevelInfo,
+		LevelWarn:  slog.LevelWarn,
+		LevelError: slog.LevelError,
+		LevelDebug: slog.LevelDebug,
+	}
+
+	level, ok := levels[logLevel]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidLogLevel, logLevel)
+	}
+
+	var handler slog.Handler
+	handlerOpts := &slog.HandlerOptions{
+		AddSource: conf.AddSource,
+		Level:     level,
+	}
+
+	switch logFormat {
+	case FormatText:
+		handler = slog.NewTextHandler(w, handlerOpts)
+	case FormatJSON:
+		handler = slog.NewJSONHandler(w, handlerOpts)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrInvalidLogFormat, logFormat)
+	}
+
+	// Add default attributes to the logger
+	attrs := make([]slog.Attr, 0)
+	for k, v := range conf.Attributes {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	logger := slog.New(handler.WithAttrs(attrs))
+
+	return logger, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR exports some of the utility code from the `cmd` package into separate packages, so that code can be re-used by external API clients.

New utility packages added.

- `pkg/utils/db` - provides utilities for creating new `bun.DB` instances from a given `config.DatabaseConfig` spec
- `pkg/utils/slog` - provides utilities for creating a new `slog.Logger` instance from a given `config.LoggingConfig` spec
- `pkg/utils/asynq/worker` - provides an abstraction of a worker built on top of `asynq.Server` and `asynq.ServeMux`, with convenience methods for adding handlers from `registry.Registry` instances.

Also, remove the no longer needed `validate{RedisConfig,WorkerConfig,DatabaseConfig}` functions from the `main` CLI package.

This change will allow new custom workers to be developed and plugged into the rest of the Inventory architecture.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Add utility packages for creating database clients, structured loggers and workers from config spec
```
