### PR TITLE
cmd: remove restriction when submitting tasks

### DIFF
--- a/cmd/inventory/tasks.go
+++ b/cmd/inventory/tasks.go
@@ -298,11 +298,6 @@ func NewTaskCommand() *cli.Command {
 					timeout := ctx.Duration("timeout")
 					queue := ctx.String("queue")
 
-					_, ok := registry.TaskRegistry.Get(taskName)
-					if !ok {
-						return fmt.Errorf("Task %q not found in the registry", taskName)
-					}
-
 					var payload []byte
 					payloadData := ctx.String("payload")
 					payloadFile := ctx.Path("payload-file")


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the restriction that the task must be registered when submitting new tasks to the queue.

We may have extension workers, which reside outside of gardener/inventory for which we don't have the tasks registered with us.

This change allows `inventory` CLI to submit new tasks for such workers as well.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- `task submit` command may enqueue tasks which are not registered with us. Allows `task submit` to be used with extension workers as well.
```
