### PR TITLE
g/tasks: allow collection of shoots via the cluster-scoped API

### DIFF
--- a/pkg/gardener/tasks/shoots.go
+++ b/pkg/gardener/tasks/shoots.go
@@ -42,15 +42,20 @@ type CollectShootsPayload struct {
 	ProjectName string `yaml:"project_name" json:"project_name"`
 
 	// ProjectNamespace represents the namespace associated with the
-	// project. When creating a new project via the Gardener Dashboard a
-	// namespace will be chosen automatically for the user, which follows
-	// the `garden-<project_name>' convention.
+	// project.
+	//
+	// When creating a new project via the Gardener Dashboard a namespace
+	// will be chosen automatically for the user, which follows the
+	// `garden-<project_name>' convention.
 	//
 	// However, if a Project is created via the API and no .spec.namespace
 	// is set for the project then the Gardener API will determine a
 	// namespace for the user. See the link below for more details.
 	//
 	// https://github.com/gardener/gardener/blob/2c445773fc3f34681e2b755f5c2c74fbee86933c/pkg/controllermanager/controller/project/project/reconciler.go#L187-L199
+	//
+	// In order to collect all shoots via the cluster-scoped API an empty
+	// project namespace may be used.
 	ProjectNamespace string `yaml:"project_namespace" json:"project_namespace"`
 }
 
@@ -88,10 +93,6 @@ func HandleCollectShootsTask(ctx context.Context, t *asynq.Task) error {
 
 	if payload.ProjectName == "" {
 		return asynqutils.SkipRetry(ErrNoProjectName)
-	}
-
-	if payload.ProjectNamespace == "" {
-		return asynqutils.SkipRetry(ErrNoProjectNamespace)
 	}
 
 	return collectShoots(ctx, payload)


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove payload restriction for having a project namespace specified.

This allows us to pass payloads with empty project namespace, which will then use the cluster-scoped API to collect the shoots. As a result collecting from large environments can be processed faster when compared to collection against each project separately.

The behaviour of the `g:task:collect-shoots` task is as follows.

a) No payload specified

In this case tasks are being enqueued for all known projects, just like we do now. This method allows for dynamic discovery and collection of shoots, as soon as new projects are populated in the Inventory database.

b) Project name and project namespace specified

Collection happens only against the project namespace provided as part of the payload.

c) Project name specified, project namespace is empty

In this collection method the task will use the cluster-scoped API in order to collect all shoots in a single pass.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- `g:task:collect-shoots` can collect Gardener Shoots using the cluster-scoped API when no project namespace is specified
```
