### PR TITLE
feat: record housekeeper run for each model 

### DIFF
--- a/internal/pkg/migrations/20250315093145_record_each_model_processed_by_the_housekeeper.tx.down.sql
+++ b/internal/pkg/migrations/20250315093145_record_each_model_processed_by_the_housekeeper.tx.down.sql
@@ -1,0 +1,20 @@
+DROP FUNCTION housekeeper_ran_in_last;
+DELETE FROM "aux_housekeeper_run";
+
+ALTER TABLE "aux_housekeeper_run"
+  DROP COLUMN "model_name",
+  DROP COLUMN "count",
+  ADD COLUMN "is_ok" boolean NOT NULL;
+
+-- housekeeper_ran_in_last function returns TRUE when the housekeeper has
+-- successfully ran in the last VAL interval, without encountering any errors.
+CREATE FUNCTION housekeeper_ran_in_last(val interval)
+RETURNS BOOLEAN AS
+$func$
+       SELECT EXISTS(
+           SELECT
+               is_ok
+           FROM aux_housekeeper_run
+           WHERE completed_at > NOW() - val AND is_ok IS TRUE
+       );
+$func$ LANGUAGE SQL STABLE;

--- a/internal/pkg/migrations/20250315093145_record_each_model_processed_by_the_housekeeper.tx.up.sql
+++ b/internal/pkg/migrations/20250315093145_record_each_model_processed_by_the_housekeeper.tx.up.sql
@@ -1,0 +1,21 @@
+DROP FUNCTION housekeeper_ran_in_last;
+DELETE FROM "aux_housekeeper_run";
+
+ALTER TABLE "aux_housekeeper_run"
+  ADD COLUMN "model_name" varchar NOT NULL,
+  ADD COLUMN "count" bigint NOT NULL,
+  DROP COLUMN "is_ok";
+
+-- housekeeper_ran_in_last function returns TRUE when the housekeeper has
+-- successfully processed stale records for a given model name in the last VAL
+-- interval.
+CREATE FUNCTION housekeeper_ran_in_last(val interval, model text)
+RETURNS BOOLEAN AS
+$func$
+       SELECT EXISTS(
+           SELECT
+               id
+           FROM aux_housekeeper_run
+           WHERE model_name = model AND completed_at > NOW() - val
+       );
+$func$ LANGUAGE SQL STABLE;

--- a/pkg/auxiliary/models/models.go
+++ b/pkg/auxiliary/models/models.go
@@ -18,6 +18,10 @@ type HousekeeperRun struct {
 	bun.BaseModel `bun:"table:aux_housekeeper_run"`
 	coremodels.Model
 
+	// ModelName specifies the name of the model processed by the
+	// housekeeper.
+	ModelName string `bun:"model_name,notnull"`
+
 	// StartedAt specifies when the housekeeper started processing stale
 	// records.
 	StartedAt time.Time `bun:"started_at,notnull"`
@@ -26,9 +30,9 @@ type HousekeeperRun struct {
 	// records.
 	CompletedAt time.Time `bun:"completed_at,notnull"`
 
-	// IsOK specifies whether the housekeeper run was successful, and
-	// completed without any errors.
-	IsOK bool `bun:"is_ok,notnull"`
+	// Count specifies the number of stale records that were cleaned up by
+	// the housekeeper.
+	Count int64 `bun:"count,notnull"`
 }
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the way the housekeeper tracks execution of stale records. The current behaviour is to track the execution of the housekeeper for _all_ models.

The new behaviour would be to track the housekeeper for each model separately. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- track housekeeper run for each model separately
```
