### PR TITLE
Fix aux:task:housekeeper bulk insert

### DIFF
--- a/pkg/auxiliary/tasks/housekeeper.go
+++ b/pkg/auxiliary/tasks/housekeeper.go
@@ -97,6 +97,10 @@ func HandleHousekeeperTask(ctx context.Context, task *asynq.Task) error {
 		}
 	}
 
+	if len(hkRuns) == 0 {
+		return nil
+	}
+
 	_, err := db.DB.NewInsert().
 		Model(&hkRuns).
 		Returning("id").


### PR DESCRIPTION
Add check for empty slice before bulk insert. An operation with an empty slice results in invalid ...VALUES() syntax.