### PR TITLE
g/tasks: skip shoots which don't have a technical id

### DIFF
--- a/pkg/gardener/tasks/shoots.go
+++ b/pkg/gardener/tasks/shoots.go
@@ -179,7 +179,18 @@ func collectShoots(ctx context.Context, payload CollectShootsPayload) error {
 		if !ok {
 			return fmt.Errorf("unexpected object type: %T", obj)
 		}
+
 		projectName, _ := strings.CutPrefix(s.Namespace, shootProjectPrefix)
+		// Skip shoots which don't have a technical id yet.
+		if s.Status.TechnicalID == "" {
+			logger.Warn(
+				"skipping shoot",
+				"name", s.Name,
+				"project", projectName,
+			)
+			return nil
+		}
+
 		cloudProfileName, err := getCloudProfileName(*s)
 		if err != nil {
 			logger.Error(


### PR DESCRIPTION
**What this PR does / why we need it**:

Skip shoots which don't have a technical id yet. When a shoot has not been scheduled on a seed cluster it's technical id remains unset, until it is scheduled. Such shoots can be skipped as they are partially created, and can be collected as part of the next collection schedule.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
g/tasks: skip shoot if it doesn't have a technical id set
```
