### PR TITLE
OpenStack Projects

### DIFF
--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -329,6 +329,17 @@ openstack:
       project: <project_name>
       region: <region>
       use_credentials: sa
+    # Used for collecting OpenStack Project metadata
+    identity:
+    - domain: <domain>
+      auth_endpoint: <endpoint>
+      # needed for differentiating between projects with the same name
+      # in different domains.
+      project_id: <project_id>
+      # needed for client creation
+      project: <project_name>
+      region: <region>
+      use_credentials: sa
 
 # Scheduler configuration
 scheduler:
@@ -479,6 +490,9 @@ scheduler:
     - name: "openstack:task:collect-subnets"
       spec: "@every 1h"
       desc: "Collect OpenStack Subnets"
+    - name: "openstack:task:collect-projects"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Projects"
 
     # Auxiliary task
     #
@@ -583,6 +597,8 @@ scheduler:
           - name: "openstack:model:loadbalancer"
             duration: 24h
           - name: "openstack:model:subnet"
+            duration: 24h
+          - name: "openstack:model:project"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -329,6 +329,17 @@ openstack:
       project: <project_name>
       region: <region>
       use_credentials: sa
+    # Used for collecting OpenStack Project metadata
+    identity:
+    - domain: <domain>
+      auth_endpoint: <endpoint>
+      # needed for differentiating between projects with the same name
+      # in different domains.
+      project_id: <project_id>
+      # needed for client creation
+      project: <project_name>
+      region: <region>
+      use_credentials: sa
 
 # Scheduler configuration
 scheduler:
@@ -479,6 +490,9 @@ scheduler:
     - name: "openstack:task:collect-subnets"
       spec: "@every 1h"
       desc: "Collect OpenStack Subnets"
+    - name: "openstack:task:collect-projects"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Projects"
 
     # Auxiliary task
     #
@@ -583,6 +597,8 @@ scheduler:
           - name: "openstack:model:loadbalancer"
             duration: 24h
           - name: "openstack:model:subnet"
+            duration: 24h
+          - name: "openstack:model:project"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/internal/pkg/migrations/20250306123353_openstack_project.tx.down.sql
+++ b/internal/pkg/migrations/20250306123353_openstack_project.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_project";

--- a/internal/pkg/migrations/20250306123353_openstack_project.tx.up.sql
+++ b/internal/pkg/migrations/20250306123353_openstack_project.tx.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "openstack_project" (
+    "project_id" varchar NOT NULL,
+    "name" varchar NOT NULL,
+    "domain" varchar NOT NULL,
+    "region" varchar NOT NULL,
+    "parent_id" varchar NOT NULL,
+    "description" varchar NOT NULL,
+    "enabled" boolean NOT NULL,
+    "is_domain" boolean NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_project_key" UNIQUE ("project_id")
+);

--- a/pkg/clients/openstack/identity.go
+++ b/pkg/clients/openstack/identity.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package openstack
+
+import (
+	"github.com/gophercloud/gophercloud/v2"
+
+	"github.com/gardener/inventory/pkg/core/registry"
+)
+
+// IdentityClientset provides the registry of OpenStack Identity API clients
+var IdentityClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -151,6 +151,9 @@ type OpenStackServices struct {
 
 	// LoadBalancer provides the LoadBalancer service configuration.
 	LoadBalancer []OpenStackServiceConfig `yaml:"load_balancer"`
+
+	// Identity provides the Identity service configuration.
+	Identity []OpenStackServiceConfig `yaml:"identity"`
 }
 
 // OpenStackServiceConfig provides configuration specific for an OpenStack service.

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -128,6 +128,21 @@ type LoadBalancerToSubnet struct {
 	SubnetID       uuid.UUID `bun:"subnet_id,notnull"`
 }
 
+// Project represents an OpenStack Project.
+type Project struct {
+	bun.BaseModel `bun:"table:openstack_project"`
+	coremodels.Model
+
+	ProjectID   string `bun:"project_id,notnull,unique:openstack_project_key"`
+	Name        string `bun:"name,notnull"`
+	Domain      string `bun:"domain,notnull"`
+	Region      string `bun:"region,notnull"`
+	ParentID    string `bun:"parent_id,notnull"`
+	Description string `bun:"description,notnull"`
+	Enabled     bool   `bun:"enabled,notnull"`
+	IsDomain    bool   `bun:"is_domain,notnull"`
+}
+
 func init() {
 	// Register the models with the default registry
 	registry.ModelRegistry.MustRegister("openstack:model:server", &Server{})
@@ -135,4 +150,5 @@ func init() {
 	registry.ModelRegistry.MustRegister("openstack:model:loadbalancer", &LoadBalancer{})
 	registry.ModelRegistry.MustRegister("openstack:model:subnet", &Subnet{})
 	registry.ModelRegistry.MustRegister("openstack:model:floating_ip", &FloatingIP{})
+	registry.ModelRegistry.MustRegister("openstack:model:project", &Project{})
 }

--- a/pkg/openstack/tasks/projects.go
+++ b/pkg/openstack/tasks/projects.go
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/hibiken/asynq"
+
+	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
+	"github.com/gardener/inventory/pkg/clients/db"
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+	"github.com/gardener/inventory/pkg/openstack/models"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// TaskCollectProjects is the name of the task for collecting OpenStack
+	// Projects.
+	TaskCollectProjects = "openstack:task:collect-projects"
+)
+
+// CollectProjectsPayload represents the payload, which specifies
+// where to collect OpenStack Projects from.
+type CollectProjectsPayload struct {
+	// Project specifies the project from which to collect.
+	ProjectID string `json:"project_id" yaml:"project_id"`
+}
+
+// NewCollectProjectsTask creates a new [asynq.Task] for collecting OpenStack
+// Projects, without specifying a payload.
+func NewCollectProjectsTask() *asynq.Task {
+	return asynq.NewTask(TaskCollectProjects, nil)
+}
+
+// HandleCollectProjectsTask handles the task for collecting OpenStack Projects.
+func HandleCollectProjectsTask(ctx context.Context, t *asynq.Task) error {
+	// If we were called without a payload, then we enqueue tasks for
+	// collecting OpenStack Projects from all configured projects.
+	data := t.Payload()
+	if data == nil {
+		return enqueueCollectProjects(ctx)
+	}
+
+	var payload CollectProjectsPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if payload.ProjectID == "" {
+		return asynqutils.SkipRetry(ErrNoProjectID)
+	}
+
+	return collectProjects(ctx, payload)
+}
+
+// enqueueCollectProjects enqueues tasks for collecting OpenStack Projects from
+// all configured OpenStack Projects by creating a payload with the respective
+// Project ID.
+func enqueueCollectProjects(ctx context.Context) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	if openstackclients.IdentityClientset.Length() == 0 {
+		logger.Warn("no OpenStack identity clients found")
+		return nil
+	}
+
+	queue := asynqutils.GetQueueName(ctx)
+
+	return openstackclients.IdentityClientset.Range(func(projectID string, client openstackclients.Client[*gophercloud.ServiceClient]) error {
+		payload := CollectProjectsPayload{
+			ProjectID: projectID,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			logger.Error(
+				"failed to marshal payload for OpenStack projects",
+				"project_id", projectID,
+				"reason", err,
+			)
+			return err
+		}
+
+		task := asynq.NewTask(TaskCollectProjects, data)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
+		if err != nil {
+			logger.Error(
+				"failed to enqueue task",
+				"type", task.Type(),
+				"project_id", projectID,
+				"reason", err,
+			)
+			return err
+		}
+
+		logger.Info(
+			"enqueued task",
+			"type", task.Type(),
+			"id", info.ID,
+			"queue", info.Queue,
+			"project_id", projectID,
+		)
+
+		return nil
+	})
+}
+
+// collectProjects collects the OpenStack Projects from the specified project,
+// using the identity client associated with the project ID in the given payload.
+func collectProjects(ctx context.Context, payload CollectProjectsPayload) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	client, ok := openstackclients.IdentityClientset.Get(payload.ProjectID)
+	if !ok {
+		return asynqutils.SkipRetry(ClientNotFound(payload.ProjectID))
+	}
+
+	region := client.Region
+	domain := client.Domain
+	projectID := payload.ProjectID
+
+	logger.Info(
+		"collecting OpenStack projects",
+		"project_id", client.ProjectID,
+		"domain", client.Domain,
+		"region", client.Region,
+		"named_credentials", client.NamedCredentials,
+	)
+
+	items := make([]models.Project, 0)
+
+	err := projects.ListAvailable(client.Client).
+		EachPage(ctx,
+			func(ctx context.Context, page pagination.Page) (bool, error) {
+				projectList, err := projects.ExtractProjects(page)
+
+				if err != nil {
+					logger.Error(
+						"could not extract project pages",
+						"reason", err,
+					)
+					return false, err
+				}
+
+				for _, p := range projectList {
+					item := models.Project{
+						ProjectID:   p.ID,
+						Name:        p.Name,
+						Domain:      domain,
+						Region:      region,
+						ParentID:    p.ParentID,
+						Description: p.Description,
+						Enabled:     p.Enabled,
+						IsDomain:    p.IsDomain,
+					}
+
+					items = append(items, item)
+				}
+
+				return true, nil
+			})
+
+	if err != nil {
+		logger.Error(
+			"could not extract project pages",
+			"reason", err,
+		)
+		return err
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	out, err := db.DB.NewInsert().
+		Model(&items).
+		On("CONFLICT (project_id) DO UPDATE").
+		Set("name = EXCLUDED.name").
+		Set("domain = EXCLUDED.domain").
+		Set("region = EXCLUDED.region").
+		Set("parent_id = EXCLUDED.parent_id").
+		Set("description = EXCLUDED.description").
+		Set("enabled = EXCLUDED.enabled").
+		Set("is_domain = EXCLUDED.is_domain").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert projects into db",
+			"project_id", projectID,
+			"region", region,
+			"domain", domain,
+			"reason", err,
+		)
+		return err
+	}
+
+	count, err := out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated openstack projects",
+		"project_id", projectID,
+		"region", region,
+		"domain", domain,
+		"count", count,
+	)
+
+	return nil
+}

--- a/pkg/openstack/tasks/tasks.go
+++ b/pkg/openstack/tasks/tasks.go
@@ -37,6 +37,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectLoadBalancersTask,
 		NewCollectSubnetsTask,
 		NewCollectFloatingIPsTask,
+		NewCollectProjectsTask,
 	}
 
 	return asynqutils.Enqueue(ctx, taskFns, asynq.Queue(queue))
@@ -61,6 +62,7 @@ func init() {
 	registry.TaskRegistry.MustRegister(TaskCollectLoadBalancers, asynq.HandlerFunc(HandleCollectLoadBalancersTask))
 	registry.TaskRegistry.MustRegister(TaskCollectSubnets, asynq.HandlerFunc(HandleCollectSubnetsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectFloatingIPs, asynq.HandlerFunc(HandleCollectFloatingIPsTask))
+	registry.TaskRegistry.MustRegister(TaskCollectProjects, asynq.HandlerFunc(HandleCollectProjectsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
 	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds task for collecting OpenStack project metadata and the needed functionality around it.
That includes using a new OpenStack service - identity.

The current implementation collects the available projects for every registered credential in the `identity` section of the OpenStack configuration. This may cause some overlap, but pulling projects per domain is currently not practical.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
OpenStack Projects
```
