### PR TITLE
OpenStack service clientset complex keys

### DIFF
--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -38,7 +38,7 @@ type configKey struct{}
 // service was not configured with a bind address.
 var errNoDashboardAddress = errors.New("no bind address specified")
 
-// errNoServiceCredentials is an error, which is returned when an cloud provider
+// errNoServiceCredentials is an error, which is returned when a cloud provider
 // API service (e.g. AWS, GCP, etc.)  does not have any named credentials
 // configured.
 var errNoServiceCredentials = errors.New("no credentials specified for service")

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -197,7 +197,7 @@ func newOpenStackProviderClient(
 	return gophercloudconfig.NewProviderClient(ctx, authOpts)
 }
 
-func configureClientset(
+func configureOpenStackServiceClientset(
 	ctx context.Context,
 	serviceName string,
 	clientset *registry.Registry[openstackclients.ClientScope, openstackclients.Client[*gophercloud.ServiceClient]],
@@ -264,27 +264,27 @@ func configureClientset(
 
 // configureOpenStackComputeClientsets configures the OpenStack Compute API clientsets.
 func configureOpenStackComputeClientsets(ctx context.Context, conf *config.Config) error {
-	return configureClientset(ctx, "compute", openstackclients.ComputeClientset, conf.OpenStack.Services.Compute, conf, openstack.NewComputeV2)
+	return configureOpenStackServiceClientset(ctx, "compute", openstackclients.ComputeClientset, conf.OpenStack.Services.Compute, conf, openstack.NewComputeV2)
 }
 
 // configureOpenStackNetworkClientsets configures the OpenStack Network API clientsets.
 func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Config) error {
-	return configureClientset(ctx, "network", openstackclients.NetworkClientset, conf.OpenStack.Services.Network, conf, openstack.NewNetworkV2)
+	return configureOpenStackServiceClientset(ctx, "network", openstackclients.NetworkClientset, conf.OpenStack.Services.Network, conf, openstack.NewNetworkV2)
 }
 
 // configureOpenStackBlockStorageClientsets configures the OpenStack Block Storage API clientsets.
 func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.Config) error {
-	return configureClientset(ctx, "block_storage", openstackclients.BlockStorageClientset,
+	return configureOpenStackServiceClientset(ctx, "block_storage", openstackclients.BlockStorageClientset,
 		conf.OpenStack.Services.BlockStorage, conf, openstack.NewBlockStorageV3)
 }
 
 // configureOpenStackLoadBalancerClientsets configures the OpenStack LoadBalancer API clientsets.
 func configureOpenStackLoadBalancerClientsets(ctx context.Context, conf *config.Config) error {
-	return configureClientset(ctx, "load_balancer", openstackclients.LoadBalancerClientset,
+	return configureOpenStackServiceClientset(ctx, "load_balancer", openstackclients.LoadBalancerClientset,
 		conf.OpenStack.Services.LoadBalancer, conf, openstack.NewLoadBalancerV2)
 }
 
 // configureOpenStackIdentityClientsets configures the OpenStack Identity API clientsets.
 func configureOpenStackIdentityClientsets(ctx context.Context, conf *config.Config) error {
-	return configureClientset(ctx, "identity", openstackclients.IdentityClientset, conf.OpenStack.Services.Identity, conf, openstack.NewIdentityV3)
+	return configureOpenStackServiceClientset(ctx, "identity", openstackclients.IdentityClientset, conf.OpenStack.Services.Identity, conf, openstack.NewIdentityV3)
 }

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -276,11 +276,28 @@ openstack:
   # and `app_credentials' for application credentials.
   credentials:
     local:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
       authentication: password
       password:
         username: "<username>"
         password_file: "<path-to-password-file>"
-    sa:
+    sa1:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
+      authentication: app_credentials
+      app_credentials:
+        app_credentials_id: "<app-id>"
+        app_credentials_secret_file: "<path-to-secret-file>"
+    sa2:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
       authentication: app_credentials
       app_credentials:
         app_credentials_id: "<app-id>"
@@ -288,58 +305,26 @@ openstack:
   services:
     # Used for collecting OpenStack Servers
     compute:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: local
+      use_credentials:
+        - local
+        - sa1
     # Used for collecting OpenStack Networks and Subnets
     network:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
+        - sa2
     block_storage:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - sa1
+        - sa2
     # Used for collecting OpenStack LoadBalancers
     load_balancer:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
     # Used for collecting OpenStack Project metadata
     identity:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
 
 # Scheduler configuration
 scheduler:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -276,11 +276,28 @@ openstack:
   # and `app_credentials' for application credentials.
   credentials:
     local:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
       authentication: password
       password:
         username: "<username>"
         password_file: "<path-to-password-file>"
-    sa:
+    sa1:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
+      authentication: app_credentials
+      app_credentials:
+        app_credentials_id: "<app-id>"
+        app_credentials_secret_file: "<path-to-secret-file>"
+    sa2:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
       authentication: app_credentials
       app_credentials:
         app_credentials_id: "<app-id>"
@@ -288,58 +305,26 @@ openstack:
   services:
     # Used for collecting OpenStack Servers
     compute:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: local
+      use_credentials:
+        - local
+        - sa1
     # Used for collecting OpenStack Networks and Subnets
     network:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
+        - sa2
     block_storage:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - sa1
+        - sa2
     # Used for collecting OpenStack LoadBalancers
     load_balancer:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
     # Used for collecting OpenStack Project metadata
     identity:
-    - domain: <domain>
-      auth_endpoint: <endpoint>
-      # needed for differentiating between projects with the same name
-      # in different domains.
-      project_id: <project_id>
-      # needed for client creation
-      project: <project_name>
-      region: <region>
-      use_credentials: sa
+      use_credentials: 
+        - local
 
 # Scheduler configuration
 scheduler:

--- a/pkg/clients/openstack/block_storage.go
+++ b/pkg/clients/openstack/block_storage.go
@@ -12,4 +12,4 @@ import (
 
 // BlockStorageClientset provides the registry of OpenStack Block Storage API clients
 // for interfacing with block storage resources.
-var BlockStorageClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()
+var BlockStorageClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/client.go
+++ b/pkg/clients/openstack/client.go
@@ -4,22 +4,29 @@
 
 package openstack
 
-// Client is a wrapper for an OpenStack API client, which comes with additional
-// metadata such as the named credentials which were used to create the client,
-// the Project ID, Region and Domain which the client is associated with.
-type Client[T any] struct {
+// ClientScope uniquely identifies the scope of the credentials used with an OpenStack
+// client
+type ClientScope struct {
 	// NamedCredentials is the name of the credentials, which were used to
 	// create the API client.
 	NamedCredentials string
 
-	// ProjectID is the project id associated with the client.
-	ProjectID string
-
-	// Region is the region associated with the client.
-	Region string
+	// Project is the project associated with the client.
+	Project string
 
 	// Domain is the domain associated with the client.
 	Domain string
+
+	// Region is the region associated with the client.
+	Region string
+}
+
+// Client is a wrapper for an OpenStack API client, which comes with additional
+// metadata such as the named credentials which were used to create the client,
+// the Project ID, Region and Domain which the client is associated with.
+type Client[T any] struct {
+	ClientScope
+
 	// Client is the client used to make API calls to the OpenStack API services.
 	Client T
 }

--- a/pkg/clients/openstack/compute.go
+++ b/pkg/clients/openstack/compute.go
@@ -12,4 +12,4 @@ import (
 
 // ComputeClientset provides the registry of OpenStack Compute API clients
 // for interfacing with compute resources (servers, etc).
-var ComputeClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()
+var ComputeClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/identity.go
+++ b/pkg/clients/openstack/identity.go
@@ -11,4 +11,4 @@ import (
 )
 
 // IdentityClientset provides the registry of OpenStack Identity API clients
-var IdentityClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()
+var IdentityClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/loadbalancer.go
+++ b/pkg/clients/openstack/loadbalancer.go
@@ -12,4 +12,4 @@ import (
 
 // LoadBalancerClientset provides the registry of OpenStack LoadBalancer API clients
 // for interfacing with load balancer resources.
-var LoadBalancerClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()
+var LoadBalancerClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/clients/openstack/network.go
+++ b/pkg/clients/openstack/network.go
@@ -12,4 +12,4 @@ import (
 
 // NetworkClientset provides the registry of OpenStack Network API clients
 // for interfacing with network resoures.
-var NetworkClientset = registry.New[string, Client[*gophercloud.ServiceClient]]()
+var NetworkClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -141,40 +141,25 @@ type OpenStackConfig struct {
 // OpenStackServices repsesents the known OpenStack services and their config.
 type OpenStackServices struct {
 	// Compute provides the Compute service configuration.
-	Compute []OpenStackServiceConfig `yaml:"compute"`
+	Compute OpenStackServiceCredentials `yaml:"compute"`
 
 	// Network provides the Network service configuration.
-	Network []OpenStackServiceConfig `yaml:"network"`
+	Network OpenStackServiceCredentials `yaml:"network"`
 
 	// BlockStorage provides the Block Storage service configuration.
-	BlockStorage []OpenStackServiceConfig `yaml:"block_storage"`
+	BlockStorage OpenStackServiceCredentials `yaml:"block_storage"`
 
 	// LoadBalancer provides the LoadBalancer service configuration.
-	LoadBalancer []OpenStackServiceConfig `yaml:"load_balancer"`
+	LoadBalancer OpenStackServiceCredentials `yaml:"load_balancer"`
 
 	// Identity provides the Identity service configuration.
-	Identity []OpenStackServiceConfig `yaml:"identity"`
+	Identity OpenStackServiceCredentials `yaml:"identity"`
 }
 
-// OpenStackServiceConfig provides configuration specific for an OpenStack service.
-type OpenStackServiceConfig struct {
-	// UseCredentials specifies the named credentials to use.
-	UseCredentials string `yaml:"use_credentials"`
-
-	// Domain specifies the domain to use when initializing the OpenStack client.
-	Domain string `yaml:"domain"`
-
-	// Project specifies the project to use when initializing the OpenStack client.
-	Project string `yaml:"project"`
-
-	// ProjectID specifies the project ID to use when initializing the OpenStack client.
-	ProjectID string `yaml:"project_id"`
-
-	// Region specifies the region to use when initializing the OpenStack client.
-	Region string `yaml:"region"`
-
-	// AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
-	AuthEndpoint string `yaml:"auth_endpoint"`
+// OpenStackServiceCredentials specifies which credentials a service can use.
+type OpenStackServiceCredentials struct {
+	// UseCredentials specifies a list of named credentials to use.
+	UseCredentials []string `yaml:"use_credentials"`
 }
 
 // OpenStackCredentialsConfig provides named credentials configuration for the OpenStack
@@ -191,6 +176,18 @@ type OpenStackCredentialsConfig struct {
 
 	// AppCredentials provides the settings to use for authentication when using application credentials.
 	AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
+
+	// Domain specifies the domain to use when initializing an OpenStack client.
+	Domain string `yaml:"domain"`
+
+	// Project specifies the project to use when initializing an OpenStack client.
+	Project string `yaml:"project"`
+
+	// Region specifies the region to use when initializing an OpenStack client.
+	Region string `yaml:"region"`
+
+	// AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
+	AuthEndpoint string `yaml:"auth_endpoint"`
 }
 
 // OpenStackPasswordConfig provides the settings to use for authentication when using username/password.

--- a/pkg/openstack/tasks/errors.go
+++ b/pkg/openstack/tasks/errors.go
@@ -13,9 +13,9 @@ import (
 // found in the clientset registries.
 var ErrClientNotFound = errors.New("client not found")
 
-// ErrNoProjectID is an error which is returned when an project id was not
+// ErrInvalidScope is an error which is returned when a valid scope was not
 // specified in a task payload.
-var ErrNoProjectID = errors.New("no project ID specified")
+var ErrInvalidScope = errors.New("invalid scope specified")
 
 // ClientNotFound wraps [ErrClientNotFound] with the given name.
 func ClientNotFound(name string) error {

--- a/pkg/openstack/tasks/floating_ips.go
+++ b/pkg/openstack/tasks/floating_ips.go
@@ -84,7 +84,9 @@ func enqueueCollectFloatingIPs(ctx context.Context) error {
 		if err != nil {
 			logger.Error(
 				"failed to marshal payload for OpenStack floating IPs",
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -96,7 +98,9 @@ func enqueueCollectFloatingIPs(ctx context.Context) error {
 			logger.Error(
 				"failed to enqueue task",
 				"type", task.Type(),
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -107,7 +111,9 @@ func enqueueCollectFloatingIPs(ctx context.Context) error {
 			"type", task.Type(),
 			"id", info.ID,
 			"queue", info.Queue,
-			"scope", scope,
+			"project", scope.Project,
+			"domain", scope.Domain,
+			"region", scope.Region,
 		)
 
 		return nil
@@ -126,7 +132,9 @@ func collectFloatingIPs(ctx context.Context, payload CollectFloatingIPsPayload) 
 
 	logger.Info(
 		"collecting OpenStack floating IPs",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.FloatingIP, 0)
@@ -218,7 +226,9 @@ func collectFloatingIPs(ctx context.Context, payload CollectFloatingIPsPayload) 
 	if err != nil {
 		logger.Error(
 			"could not insert floating IPs into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -231,7 +241,9 @@ func collectFloatingIPs(ctx context.Context, payload CollectFloatingIPsPayload) 
 
 	logger.Info(
 		"populated openstack floating IPs",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/tasks/loadbalancers.go
+++ b/pkg/openstack/tasks/loadbalancers.go
@@ -81,7 +81,9 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 			if err != nil {
 				logger.Error(
 					"failed to marshal payload for OpenStack load balancers",
-					"scope", scope,
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
 					"reason", err,
 				)
 				return err
@@ -93,7 +95,9 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 				logger.Error(
 					"failed to enqueue task",
 					"type", task.Type(),
-					"scope", scope,
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
 					"reason", err,
 				)
 				return err
@@ -104,7 +108,9 @@ func enqueueCollectLoadBalancers(ctx context.Context) error {
 				"type", task.Type(),
 				"id", info.ID,
 				"queue", info.Queue,
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 			)
 
 			return nil
@@ -123,7 +129,9 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 
 	logger.Info(
 		"collecting OpenStack load balancers",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.LoadBalancer, 0)
@@ -136,7 +144,9 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 				if err != nil {
 					logger.Error(
 						"could not extract load balancers pages",
-						"scope", payload.Scope,
+						"project", payload.Scope.Project,
+						"domain", payload.Scope.Domain,
+						"region", payload.Scope.Region,
 						"reason", err,
 					)
 					return false, err
@@ -198,7 +208,9 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 	if err != nil {
 		logger.Error(
 			"could not insert load balancers into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -211,7 +223,9 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 
 	logger.Info(
 		"populated openstack load balancers",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/tasks/networks.go
+++ b/pkg/openstack/tasks/networks.go
@@ -83,7 +83,9 @@ func enqueueCollectNetworks(ctx context.Context) error {
 		if err != nil {
 			logger.Error(
 				"failed to marshal payload for OpenStack networks",
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -95,7 +97,9 @@ func enqueueCollectNetworks(ctx context.Context) error {
 			logger.Error(
 				"failed to enqueue task",
 				"type", task.Type(),
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -106,7 +110,9 @@ func enqueueCollectNetworks(ctx context.Context) error {
 			"type", task.Type(),
 			"id", info.ID,
 			"queue", info.Queue,
-			"scope", scope,
+			"project", scope.Project,
+			"domain", scope.Domain,
+			"region", scope.Region,
 		)
 
 		return nil
@@ -125,7 +131,9 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 
 	logger.Info(
 		"collecting OpenStack networks",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.Network, 0)
@@ -193,7 +201,9 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 	if err != nil {
 		logger.Error(
 			"could not insert networks into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -206,7 +216,9 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 
 	logger.Info(
 		"populated openstack networks",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/tasks/projects.go
+++ b/pkg/openstack/tasks/projects.go
@@ -82,7 +82,9 @@ func enqueueCollectProjects(ctx context.Context) error {
 		if err != nil {
 			logger.Error(
 				"failed to marshal payload for OpenStack projects",
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -94,7 +96,9 @@ func enqueueCollectProjects(ctx context.Context) error {
 			logger.Error(
 				"failed to enqueue task",
 				"type", task.Type(),
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -105,7 +109,9 @@ func enqueueCollectProjects(ctx context.Context) error {
 			"type", task.Type(),
 			"id", info.ID,
 			"queue", info.Queue,
-			"scope", scope,
+			"project", scope.Project,
+			"domain", scope.Domain,
+			"region", scope.Region,
 		)
 
 		return nil
@@ -124,7 +130,9 @@ func collectProjects(ctx context.Context, payload CollectProjectsPayload) error 
 
 	logger.Info(
 		"collecting OpenStack projects",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.Project, 0)
@@ -189,7 +197,9 @@ func collectProjects(ctx context.Context, payload CollectProjectsPayload) error 
 	if err != nil {
 		logger.Error(
 			"could not insert projects into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -202,7 +212,9 @@ func collectProjects(ctx context.Context, payload CollectProjectsPayload) error 
 
 	logger.Info(
 		"populated openstack projects",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/tasks/servers.go
+++ b/pkg/openstack/tasks/servers.go
@@ -82,7 +82,9 @@ func enqueueCollectServers(ctx context.Context) error {
 		if err != nil {
 			logger.Error(
 				"failed to marshal payload for OpenStack servers",
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -94,7 +96,9 @@ func enqueueCollectServers(ctx context.Context) error {
 			logger.Error(
 				"failed to enqueue task",
 				"type", task.Type(),
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -105,7 +109,9 @@ func enqueueCollectServers(ctx context.Context) error {
 			"type", task.Type(),
 			"id", info.ID,
 			"queue", info.Queue,
-			"scope", scope,
+			"project", scope.Project,
+			"domain", scope.Domain,
+			"region", scope.Region,
 		)
 
 		return nil
@@ -124,7 +130,9 @@ func collectServers(ctx context.Context, payload CollectServersPayload) error {
 
 	logger.Info(
 		"collecting OpenStack servers",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.Server, 0)
@@ -201,7 +209,9 @@ func collectServers(ctx context.Context, payload CollectServersPayload) error {
 	if err != nil {
 		logger.Error(
 			"could not insert servers into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -214,7 +224,9 @@ func collectServers(ctx context.Context, payload CollectServersPayload) error {
 
 	logger.Info(
 		"populated openstack servers",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/tasks/subnets.go
+++ b/pkg/openstack/tasks/subnets.go
@@ -82,7 +82,9 @@ func enqueueCollectSubnets(ctx context.Context) error {
 		if err != nil {
 			logger.Error(
 				"failed to marshal payload for OpenStack subnets",
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -94,7 +96,9 @@ func enqueueCollectSubnets(ctx context.Context) error {
 			logger.Error(
 				"failed to enqueue task",
 				"type", task.Type(),
-				"scope", scope,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
 				"reason", err,
 			)
 			return err
@@ -105,7 +109,9 @@ func enqueueCollectSubnets(ctx context.Context) error {
 			"type", task.Type(),
 			"id", info.ID,
 			"queue", info.Queue,
-			"scope", scope,
+			"project", scope.Project,
+			"domain", scope.Domain,
+			"region", scope.Region,
 		)
 
 		return nil
@@ -124,7 +130,9 @@ func collectSubnets(ctx context.Context, payload CollectSubnetsPayload) error {
 
 	logger.Info(
 		"collecting OpenStack subnets",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 	)
 
 	items := make([]models.Subnet, 0)
@@ -196,7 +204,9 @@ func collectSubnets(ctx context.Context, payload CollectSubnetsPayload) error {
 	if err != nil {
 		logger.Error(
 			"could not insert Subnets into db",
-			"scope", payload.Scope,
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err
@@ -209,7 +219,9 @@ func collectSubnets(ctx context.Context, payload CollectSubnetsPayload) error {
 
 	logger.Info(
 		"populated openstack subnets",
-		"scope", payload.Scope,
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
 		"count", count,
 	)
 

--- a/pkg/openstack/utils/utils.go
+++ b/pkg/openstack/utils/utils.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"errors"
+
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+)
+
+// IsValidDomainScope can be used to check the scope fields are set for usage
+// on the domain level.
+func IsValidDomainScope(scope openstackclients.ClientScope) error {
+	if scope.Region == "" {
+		return errors.New("missing region")
+	}
+
+	if scope.Domain == "" {
+		return errors.New("missing domain")
+	}
+
+	if scope.NamedCredentials == "" {
+		return errors.New("missing named credentials")
+	}
+
+	return nil
+}
+
+// IsValidProjectScope can be used to check the scope fields are set for usage
+// on the project level.
+func IsValidProjectScope(scope openstackclients.ClientScope) error {
+	err := IsValidDomainScope(scope)
+	if err != nil {
+		return err
+	}
+
+	if scope.Project == "" {
+		return errors.New("missing project name")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR removes project id as the key for openstack service clients. This was the "easy" way to differentiate between different clients, but added extra when configuring the inventory - you had to find out the openstack project ids you were targeting and put them in the config.yaml. Now, a composite key is used, consisting of named_credential, project_name, domain, region. This information is provided anyways, so no project_id needs to be specified anymore.

**Release note**:
```feature user
OpenStack complex keys for service clientsets.
```
