### PR TITLE
deps: bump golangci-lint to v1.64.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MINIKUBE                     := $(TOOLS_BIN)/minikube
 
 GOIMPORTS_VERSION            ?= $(call version_gomod,golang.org/x/tools)
 GOIMPORTS_REVISER_VERSION    ?= v3.6.5
-GOLANGCI_LINT_VERSION        ?= v1.60.1
+GOLANGCI_LINT_VERSION        ?= v1.64.8
 KUSTOMIZE_VERSION            ?= v5.4.2
 MINIKUBE_VERSION 	     ?= v1.33.1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump `golangci-lint` to v1.64.8.

In the next iteration we will be moving to v2 of `golangci-lint` and the newly added [Tool dependencies
](https://go.dev/doc/modules/managing-dependencies#tools)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Bump golangci-lint to 1.64.8
```
