### PR TITLE
Fix Cloud Profile Azure Image

### DIFF
--- a/internal/pkg/migrations/20250407135141_g_cloud_profile_azure_image_add_image_id.tx.down.sql
+++ b/internal/pkg/migrations/20250407135141_g_cloud_profile_azure_image_add_image_id.tx.down.sql
@@ -1,0 +1,27 @@
+ALTER TABLE "g_cloud_profile_azure_image" DROP CONSTRAINT "g_cloud_profile_azure_image_key";
+-- cascade drops the "az_unknown_image" view
+ALTER TABLE "g_cloud_profile_azure_image" DROP COLUMN "image_id" CASCADE;
+ALTER TABLE "g_cloud_profile_azure_image" ADD COLUMN "gallery_image_id" varchar NOT NULL;
+ALTER TABLE "g_cloud_profile_azure_image" ADD COLUMN "urn" varchar NOT NULL;
+ALTER TABLE "g_cloud_profile_azure_image" ADD CONSTRAINT "g_cloud_profile_azure_image_key" UNIQUE ("name", "version", "architecture", "cloud_profile_name");
+
+CREATE OR REPLACE VIEW "az_unknown_image" AS
+SELECT
+        vm.name as vm_name,
+        vm.subscription_id,
+        vm.resource_group,
+        vm.location,
+        vm.power_state,
+        vm.created_at,
+        vm.updated_at,
+        s.name AS shoot_name,
+        s.technical_id as shoot_technical_id,
+        s.project_name as shoot_project_name,
+        cpai.name image_name,
+        vm.gallery_image_id
+FROM az_vm AS vm
+INNER JOIN g_machine AS m ON vm.name = m.name
+INNER JOIN g_shoot AS s ON m.namespace = s.technical_id
+LEFT JOIN g_cloud_profile_azure_image AS cpai ON s.cloud_profile = cpai.cloud_profile_name
+AND vm.gallery_image_id = cpai.gallery_image_id
+WHERE cpai.name IS NULL;

--- a/internal/pkg/migrations/20250407135141_g_cloud_profile_azure_image_add_image_id.tx.up.sql
+++ b/internal/pkg/migrations/20250407135141_g_cloud_profile_azure_image_add_image_id.tx.up.sql
@@ -1,0 +1,29 @@
+TRUNCATE "g_cloud_profile_azure_image" CASCADE; 
+
+ALTER TABLE "g_cloud_profile_azure_image" DROP CONSTRAINT "g_cloud_profile_azure_image_key";
+-- cascade deletes the "az_unknown_image" view
+ALTER TABLE "g_cloud_profile_azure_image" DROP COLUMN "gallery_image_id" CASCADE;
+ALTER TABLE "g_cloud_profile_azure_image" DROP COLUMN "urn";
+ALTER TABLE "g_cloud_profile_azure_image" ADD COLUMN "image_id" varchar NOT NULL;
+ALTER TABLE "g_cloud_profile_azure_image" ADD CONSTRAINT "g_cloud_profile_azure_image_key" UNIQUE ("name", "version", "architecture", "cloud_profile_name", "image_id");
+
+CREATE OR REPLACE VIEW "az_unknown_image" AS
+SELECT
+        vm.name as vm_name,
+        vm.subscription_id,
+        vm.resource_group,
+        vm.location,
+        vm.power_state,
+        vm.created_at,
+        vm.updated_at,
+        vm.gallery_image_id,
+        cpai.name image_name,
+        s.name AS shoot_name,
+        s.technical_id as shoot_technical_id,
+        s.project_name as shoot_project_name
+FROM az_vm AS vm
+INNER JOIN g_machine AS m ON vm.name = m.name
+INNER JOIN g_shoot AS s ON m.namespace = s.technical_id
+LEFT JOIN g_cloud_profile_azure_image AS cpai ON s.cloud_profile = cpai.cloud_profile_name
+AND vm.gallery_image_id = cpai.image_id
+WHERE cpai.name IS NULL;

--- a/pkg/gardener/models/models.go
+++ b/pkg/gardener/models/models.go
@@ -212,8 +212,7 @@ type CloudProfileAzureImage struct {
 	Version          string        `bun:"version,notnull,unique:g_cloud_profile_azure_image_key"`
 	Architecture     string        `bun:"architecture,notnull,unique:g_cloud_profile_azure_image_key"`
 	CloudProfileName string        `bun:"cloud_profile_name,notnull,unique:g_cloud_profile_azure_image_key"`
-	URN              string        `bun:"urn,notnull"`
-	GalleryImageID   string        `bun:"gallery_image_id,notnull"`
+	ImageID          string        `bun:"image_id,notnull,unique:g_cloud_profile_azure_image_key"`
 	CloudProfile     *CloudProfile `bun:"rel:has-one,join:cloud_profile_name=name"`
 }
 


### PR DESCRIPTION
Fixes Cloud Profile Azure image collection by combining gallery_image_id and urn into a single column - image_id,
which gets populated by whichever of the two fields is set.
Changes in db:
- g_cloud_profile_azure_image: changes above
- az_unknown_image (view): referred gallery_image_id, has been updated to image_id

A single migration file pair has been used for both of the above changes, since a nonstandard ordering is required (change table first, view second).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fix Cloud Profile Azure Image collection
```
