### PR TITLE
core/config: `Parse` ignores empty paths

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -682,6 +682,11 @@ func Parse(paths ...string) (*Config, error) {
 	var conf Config
 
 	for _, path := range paths {
+		// Ignore empty paths
+		if path == "" {
+			continue
+		}
+
 		if err := ParseFileInto(path, &conf); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

`core/config.Parse()` ignores empty paths.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- `config/config.Parse` ignores empty paths
```
