### PR TITLE
cmd: `--worker` flag is not required for `worker ping` sub-command

### DIFF
--- a/cmd/inventory/worker.go
+++ b/cmd/inventory/worker.go
@@ -90,7 +90,7 @@ func NewWorkerCommand() *cli.Command {
 					&cli.StringFlag{
 						Name:     "worker",
 						Usage:    "worker name to ping",
-						Required: true,
+						Required: false,
 						Aliases:  []string{"name"},
 					},
 					&cli.BoolFlag{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`worker ping --worker` flag is not required since we have added `--local` flag
```
