### PR TITLE
Makefile: add target for updating Go tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
       - dependency-name: github.com/gardener/*
         versions:
           - "*"
+
+  # Create PRs for tool updates
+  - package-ecosystem: gomod
+    directory: /tools
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "tools: "
+
   # Create PRs for golang version updates
   - package-ecosystem: docker
     directory: /

--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,7 @@ minikube-load-image: $(MINIKUBE)
 	docker image save -o image.tar $(IMAGE):latest
 	$(MINIKUBE) -p $(MINIKUBE_PROFILE) image load --overwrite=true image.tar
 	rm -f image.tar
+
+.PHONY: update-tools
+update-tools:
+	go get -u -modfile tools/go.mod tool


### PR DESCRIPTION
**What this PR does / why we need it**:
Add target to update Go tools and handle updates using dependabot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add target to update Go tools and handle updates using dependabot.
```
