### PR TITLE
Bump postgres and prometheus versions

### DIFF
--- a/deployment/kustomize/postgres/statefulset.yaml
+++ b/deployment/kustomize/postgres/statefulset.yaml
@@ -33,7 +33,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: postgres:16.2-bookworm
+        image: postgres:17.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432

--- a/deployment/kustomize/prometheus/base/statefulset.yaml
+++ b/deployment/kustomize/prometheus/base/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
           capabilities:
             drop:
             - "ALL"
-        image: prom/prometheus:v2.52.0
+        image: prom/prometheus:v3.3.1
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name: prometheus-config-vol

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
   postgres:
     ports:
       - 5432:5432
-    image: postgres:16.2-bookworm
+    image: postgres:17.4
     environment:
       POSTGRES_USER: *postgres-user
       POSTGRES_PASSWORD: *postgres-password
@@ -120,7 +120,7 @@ services:
       - ./extra/grafana/dashboards:/var/lib/grafana/dashboards
 
   prometheus:
-    image: prom/prometheus:v2.52.0
+    image: prom/prometheus:v3.3.1
     ports:
       - 9090:9090
     depends_on:
@@ -131,7 +131,7 @@ services:
       - ./dev/local/prometheus:/prometheus
 
   pgadmin:
-    image: dpage/pgadmin4:8.8
+    image: dpage/pgadmin4:9.3.0
     ports:
       - 7080:80
     environment:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps versions of the following services.

- Postgres to 17.4
- Prometheus to v3.3.1
- pgadmin to 9.3.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Bump Postgres to 17.4
- Bump Prometheus to v3.3.1
- Bump pgadmin to 9.3.0
```
