### PR TITLE
Openstack Objects

### DIFF
--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -34,11 +34,11 @@ var errNoProject = errors.New("no project specified")
 func validateOpenStackConfig(conf *config.Config) error {
 	// Make sure that the services have named credentials configured.
 	services := map[string]config.OpenStackServiceCredentials{
-		"compute":       conf.OpenStack.Services.Compute,
-		"network":       conf.OpenStack.Services.Network,
-		"block_storage": conf.OpenStack.Services.BlockStorage,
-		"load_balancer": conf.OpenStack.Services.LoadBalancer,
-		"identity":      conf.OpenStack.Services.Identity,
+		"compute":        conf.OpenStack.Services.Compute,
+		"network":        conf.OpenStack.Services.Network,
+		"object_storage": conf.OpenStack.Services.ObjectStorage,
+		"load_balancer":  conf.OpenStack.Services.LoadBalancer,
+		"identity":       conf.OpenStack.Services.Identity,
 	}
 
 	for name, creds := range conf.OpenStack.Credentials {
@@ -124,11 +124,11 @@ func configureOpenStackClients(ctx context.Context, conf *config.Config) error {
 	}
 
 	configFuncs := map[string]func(ctx context.Context, conf *config.Config) error{
-		"compute":       configureOpenStackComputeClientsets,
-		"network":       configureOpenStackNetworkClientsets,
-		"block_storage": configureOpenStackBlockStorageClientsets,
-		"load_balancer": configureOpenStackLoadBalancerClientsets,
-		"identity":      configureOpenStackIdentityClientsets,
+		"compute":        configureOpenStackComputeClientsets,
+		"network":        configureOpenStackNetworkClientsets,
+		"object_storage": configureOpenStackObjectStorageClientsets,
+		"load_balancer":  configureOpenStackLoadBalancerClientsets,
+		"identity":       configureOpenStackIdentityClientsets,
 	}
 
 	for svc, configFunc := range configFuncs {
@@ -265,10 +265,10 @@ func configureOpenStackNetworkClientsets(ctx context.Context, conf *config.Confi
 	return configureOpenStackServiceClientset(ctx, "network", openstackclients.NetworkClientset, conf.OpenStack.Services.Network, conf, openstack.NewNetworkV2)
 }
 
-// configureOpenStackBlockStorageClientsets configures the OpenStack Block Storage API clientsets.
-func configureOpenStackBlockStorageClientsets(ctx context.Context, conf *config.Config) error {
-	return configureOpenStackServiceClientset(ctx, "block_storage", openstackclients.BlockStorageClientset,
-		conf.OpenStack.Services.BlockStorage, conf, openstack.NewBlockStorageV3)
+// configureOpenStackObjectStorageClientsets configures the OpenStack Object Storage API clientsets.
+func configureOpenStackObjectStorageClientsets(ctx context.Context, conf *config.Config) error {
+	return configureOpenStackServiceClientset(ctx, "object_storage", openstackclients.ObjectStorageClientset,
+		conf.OpenStack.Services.ObjectStorage, conf, openstack.NewObjectStorageV1)
 }
 
 // configureOpenStackLoadBalancerClientsets configures the OpenStack LoadBalancer API clientsets.

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -313,7 +313,8 @@ openstack:
       use_credentials:
         - local
         - sa2
-    block_storage:
+    # Used for collecting OpenStack Objects
+    object_storage:
       use_credentials:
         - sa1
         - sa2
@@ -478,6 +479,9 @@ scheduler:
     - name: "openstack:task:collect-projects"
       spec: "@every 1h"
       desc: "Collect OpenStack Projects"
+    - name: "openstack:task:collect-objects"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Objects"
 
     # Auxiliary task
     #
@@ -584,6 +588,8 @@ scheduler:
           - name: "openstack:model:subnet"
             duration: 24h
           - name: "openstack:model:project"
+            duration: 24h
+          - name: "openstack:model:object"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -313,7 +313,8 @@ openstack:
       use_credentials:
         - local
         - sa2
-    block_storage:
+    # Used for collecting OpenStack Objects
+    object_storage:
       use_credentials:
         - sa1
         - sa2
@@ -478,6 +479,9 @@ scheduler:
     - name: "openstack:task:collect-projects"
       spec: "@every 1h"
       desc: "Collect OpenStack Projects"
+    - name: "openstack:task:collect-objects"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Objects"
 
     # Auxiliary task
     #
@@ -584,6 +588,8 @@ scheduler:
           - name: "openstack:model:subnet"
             duration: 24h
           - name: "openstack:model:project"
+            duration: 24h
+          - name: "openstack:model:object"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/internal/pkg/migrations/20250502124652_add_openstack_object.tx.down.sql
+++ b/internal/pkg/migrations/20250502124652_add_openstack_object.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_object";

--- a/internal/pkg/migrations/20250502124652_add_openstack_object.tx.up.sql
+++ b/internal/pkg/migrations/20250502124652_add_openstack_object.tx.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "openstack_object" (
+    "name" varchar NOT NULL,
+    "project_id" varchar NOT NULL,
+    "container_name" varchar NOT NULL,
+    "content_type" varchar NOT NULL,
+    "last_modified" timestamptz NOT NULL,
+    "is_latest" boolean NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "openstack_object_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_object_key" UNIQUE ("name", "project_id", "container_name")
+);

--- a/pkg/clients/openstack/object_storage.go
+++ b/pkg/clients/openstack/object_storage.go
@@ -10,6 +10,6 @@ import (
 	"github.com/gardener/inventory/pkg/core/registry"
 )
 
-// BlockStorageClientset provides the registry of OpenStack Block Storage API clients
-// for interfacing with block storage resources.
-var BlockStorageClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()
+// ObjectStorageClientset provides the registry of OpenStack Object Storage API clients
+// for interfacing with object storage resources (containers, objects, etc).
+var ObjectStorageClientset = registry.New[ClientScope, Client[*gophercloud.ServiceClient]]()

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -146,8 +146,8 @@ type OpenStackServices struct {
 	// Network provides the Network service configuration.
 	Network OpenStackServiceCredentials `yaml:"network"`
 
-	// BlockStorage provides the Block Storage service configuration.
-	BlockStorage OpenStackServiceCredentials `yaml:"block_storage"`
+	// ObjectStorage provides the object Storage service configuration.
+	ObjectStorage OpenStackServiceCredentials `yaml:"object_storage"`
 
 	// LoadBalancer provides the LoadBalancer service configuration.
 	LoadBalancer OpenStackServiceCredentials `yaml:"load_balancer"`

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -258,6 +258,19 @@ type RouterExternalIP struct {
 	Project          *Project `bun:"rel:has-one,join:project_id=project_id"`
 }
 
+// Object represents an OpenStack Object.
+type Object struct {
+	bun.BaseModel `bun:"table:openstack_object"`
+	coremodels.Model
+
+	Name          string    `bun:"name,notnull,unique:openstack_object_key"`
+	ProjectID     string    `bun:"project_id,notnull,unique:openstack_object_key"`
+	ContainerName string    `bun:"container_name,notnull,unique:openstack_object_key"`
+	ContentType   string    `bun:"content_type,notnull"`
+	LastModified  time.Time `bun:"last_modified,notnull"`
+	IsLatest      bool      `bun:"is_latest,notnull"`
+}
+
 func init() {
 	// Register the models with the default registry
 	registry.ModelRegistry.MustRegister("openstack:model:server", &Server{})
@@ -277,4 +290,5 @@ func init() {
 	registry.ModelRegistry.MustRegister("openstack:model:port_ip", &PortIP{})
 	registry.ModelRegistry.MustRegister("openstack:model:router", &Router{})
 	registry.ModelRegistry.MustRegister("openstack:model:router_external_ip", &RouterExternalIP{})
+	registry.ModelRegistry.MustRegister("openstack:model:object", &Object{})
 }

--- a/pkg/openstack/tasks/objects.go
+++ b/pkg/openstack/tasks/objects.go
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1/containers"
+	"github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1/objects"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/hibiken/asynq"
+
+	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
+	"github.com/gardener/inventory/pkg/clients/db"
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+	"github.com/gardener/inventory/pkg/openstack/models"
+	openstackutils "github.com/gardener/inventory/pkg/openstack/utils"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// TaskCollectObjects is the name of the task for collecting OpenStack
+	// Objects.
+	TaskCollectObjects = "openstack:task:collect-objects"
+)
+
+// CollectObjectsPayload represents the payload, which specifies
+// where to collect OpenStack Objects from.
+type CollectObjectsPayload struct {
+	// Scope specifies the client scope for which to collect.
+	Scope openstackclients.ClientScope `json:"scope" yaml:"scope"`
+}
+
+// NewCollectObjectsTask creates a new [asynq.Task] for collecting OpenStack
+// Objects, without specifying a payload.
+func NewCollectObjectsTask() *asynq.Task {
+	return asynq.NewTask(TaskCollectObjects, nil)
+}
+
+// HandleCollectObjectsTask handles the task for collecting OpenStack Objects.
+func HandleCollectObjectsTask(ctx context.Context, t *asynq.Task) error {
+	// If we were called without a payload, then we enqueue tasks for
+	// collecting OpenStack Objects from all configured object clients.
+	data := t.Payload()
+	if data == nil {
+		return enqueueCollectObjects(ctx)
+	}
+
+	var payload CollectObjectsPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if err := openstackutils.IsValidProjectScope(payload.Scope); err != nil {
+		return asynqutils.SkipRetry(ErrInvalidScope)
+	}
+
+	return collectObjects(ctx, payload)
+}
+
+// enqueueCollectObjects enqueues tasks for collecting OpenStack Objects from
+// all configured OpenStack Object clients by creating a payload with the respective
+// client scope.
+func enqueueCollectObjects(ctx context.Context) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	if openstackclients.ObjectStorageClientset.Length() == 0 {
+		logger.Warn("no OpenStack object storage clients found")
+		return nil
+	}
+
+	queue := asynqutils.GetQueueName(ctx)
+
+	return openstackclients.ObjectStorageClientset.
+		Range(func(scope openstackclients.ClientScope, client openstackclients.Client[*gophercloud.ServiceClient]) error {
+			payload := CollectObjectsPayload{
+				Scope: scope,
+			}
+			data, err := json.Marshal(payload)
+			if err != nil {
+				logger.Error(
+					"failed to marshal payload for OpenStack objects",
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			task := asynq.NewTask(TaskCollectObjects, data)
+			info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
+			if err != nil {
+				logger.Error(
+					"failed to enqueue task",
+					"type", task.Type(),
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			logger.Info(
+				"enqueued task",
+				"type", task.Type(),
+				"id", info.ID,
+				"queue", info.Queue,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
+			)
+
+			return nil
+		})
+}
+
+// collectObject collects the OpenStack Objects,
+// using the client associated with the client scope in the given payload.
+func collectObjects(ctx context.Context, payload CollectObjectsPayload) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	client, ok := openstackclients.ObjectStorageClientset.Get(payload.Scope)
+	if !ok {
+		return asynqutils.SkipRetry(ClientNotFound(payload.Scope.Project))
+	}
+
+	logger.Info(
+		"collecting OpenStack objects",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+	)
+
+	containerNames := make([]string, 0)
+	items := make([]models.Object, 0)
+
+	err := containers.List(client.Client, nil).
+		EachPage(ctx,
+			func(ctx context.Context, page pagination.Page) (bool, error) {
+				containerNameList, err := containers.ExtractNames(page)
+
+				if err != nil {
+					logger.Error(
+						"could not extract container pages",
+						"reason", err,
+					)
+					return false, err
+				}
+
+				containerNames = append(containerNames, containerNameList...)
+
+				return true, nil
+			})
+
+	if err != nil {
+		logger.Error(
+			"could not extract container pages",
+			"reason", err,
+		)
+		return err
+	}
+
+	for _, name := range containerNames {
+		err = objects.List(client.Client, name, nil).
+			EachPage(ctx,
+				func(ctx context.Context, page pagination.Page) (bool, error) {
+					objectList, err := objects.ExtractInfo(page)
+
+					if err != nil {
+						logger.Error(
+							"could not extract object pages",
+							"reason", err,
+						)
+						return false, err
+					}
+
+					for _, o := range objectList {
+						item := models.Object{
+							Name:          o.Name,
+							ContainerName: name,
+							ProjectID:     client.Project,
+							ContentType:   o.ContentType,
+							LastModified:  o.LastModified,
+							IsLatest:      o.IsLatest,
+						}
+
+						items = append(items, item)
+					}
+
+					return true, nil
+				})
+
+		if err != nil {
+			logger.Warn(
+				"could not extract object pages",
+				"container",
+				name,
+				"reason", err,
+			)
+			continue
+		}
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	out, err := db.DB.NewInsert().
+		Model(&items).
+		On("CONFLICT (name, container_name, project_id) DO UPDATE").
+		Set("content_type = EXCLUDED.content_type").
+		Set("last_modified = EXCLUDED.last_modified").
+		Set("is_latest = EXCLUDED.is_latest").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert objects into db",
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
+			"reason", err,
+		)
+		return err
+	}
+
+	count, err := out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated openstack objects",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+		"count", count,
+	)
+
+	return nil
+}

--- a/pkg/openstack/tasks/tasks.go
+++ b/pkg/openstack/tasks/tasks.go
@@ -40,6 +40,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectProjectsTask,
 		NewCollectRoutersTask,
 		NewCollectPortsTask,
+		NewCollectObjectsTask,
 	}
 
 	return asynqutils.Enqueue(ctx, taskFns, asynq.Queue(queue))
@@ -72,6 +73,7 @@ func init() {
 	registry.TaskRegistry.MustRegister(TaskCollectProjects, asynq.HandlerFunc(HandleCollectProjectsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectRouters, asynq.HandlerFunc(HandleCollectRoutersTask))
 	registry.TaskRegistry.MustRegister(TaskCollectPorts, asynq.HandlerFunc(HandleCollectPortsTask))
+	registry.TaskRegistry.MustRegister(TaskCollectObjects, asynq.HandlerFunc(HandleCollectObjectsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
 	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Task for collecting Openstack Objects. 
Openstack has another abstraction - containers, but the metadata for those is lacking, so I have added a container_name column to the object schema.
This PR introduces the following:
model:
openstack:model:object
task:
openstack:task:collect-objects
db table:
openstack_object

The objects are currently unfiltered, so all objects we have access to will be collected.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Openstack Objects
```
