### PR TITLE
OpenStack reauthentication fix

### DIFF
--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -189,6 +189,7 @@ func newOpenStackProviderClient(
 			IdentityEndpoint:            creds.AuthEndpoint,
 			ApplicationCredentialID:     appID,
 			ApplicationCredentialSecret: appSecret,
+			AllowReauth: true,
 		}
 	default:
 		return nil, fmt.Errorf("unknown authentication method: %s", creds.Authentication)

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -168,6 +168,7 @@ func newOpenStackProviderClient(
 			TenantName:       creds.Project,
 			Username:         username,
 			Password:         password,
+			AllowReauth:      true,
 		}
 	case config.OpenStackAuthenticationMethodAppCredentials:
 		appID := strings.TrimSpace(creds.AppCredentials.AppCredentialsID)
@@ -189,7 +190,7 @@ func newOpenStackProviderClient(
 			IdentityEndpoint:            creds.AuthEndpoint,
 			ApplicationCredentialID:     appID,
 			ApplicationCredentialSecret: appSecret,
-			AllowReauth: true,
+			AllowReauth:                 true,
 		}
 	default:
 		return nil, fmt.Errorf("unknown authentication method: %s", creds.Authentication)

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -479,7 +479,7 @@ scheduler:
     - name: "openstack:task:collect-projects"
       spec: "@every 1h"
       desc: "Collect OpenStack Projects"
-    - name: "openstack:task:collect-floating_ips"
+    - name: "openstack:task:collect-floating-ips"
       spec: "@every 1h"
       desc: "Collect OpenStack Floating IPs"
     - name: "openstack:task:collect-ports"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -484,7 +484,7 @@ scheduler:
     - name: "openstack:task:collect-projects"
       spec: "@every 1h"
       desc: "Collect OpenStack Projects"
-    - name: "openstack:task:collect-floating_ips"
+    - name: "openstack:task:collect-floating-ips"
       spec: "@every 1h"
       desc: "Collect OpenStack Floating IPs"
     - name: "openstack:task:collect-ports"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a flag to tell the client to attempt to reauthenticate when the KeyStone token expires.
This mechanism doesn't backoff when reauthentication fails, so this can potentially lead to a lot of requests to Keystone,
but we can implement a throttle mechanism if the need arises.

Also fixing a type in openstack:task:collect-floating-ips