### PR TITLE
OpenStack: Pool, PoolMembers, Utility network resource mappings

### DIFF
--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -88,6 +88,11 @@ azure:
       use_credentials:
         - foo
 
+    # Graph API clients. Used for collecting Microsoft Entra user accounts.
+    graph:
+      use_credentials:
+        - foo
+
   # The `credentials' section provides named credentials, which are used by the
   # various Azure services. The currently supported authentication mechanisms
   # are `default' and `workload_identity'.
@@ -491,6 +496,9 @@ scheduler:
     - name: "openstack:task:collect-objects"
       spec: "@every 1h"
       desc: "Collect OpenStack Objects"
+    - name: "openstack:task:collect-pools"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Pools"
 
     # Auxiliary task
     #
@@ -587,6 +595,8 @@ scheduler:
             duration: 24h
           - name: "az:model:blob_container"
             duration: 24h
+          - name: "az:model:user"
+            duration: 24h
           # OpenStack
           - name: "openstack:model:server"
             duration: 24h
@@ -609,6 +619,12 @@ scheduler:
           - name: "openstack:model:router_external_ip"
             duration: 24h
           - name: "openstack:model:object"
+            duration: 24h
+          - name: "openstack:model:pool"
+            duration: 24h
+          - name: "openstack:model:pool_member"
+            duration: 24h
+          - name: "openstack:model:loadbalancer_with_pool"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -496,6 +496,9 @@ scheduler:
     - name: "openstack:task:collect-objects"
       spec: "@every 1h"
       desc: "Collect OpenStack Objects"
+    - name: "openstack:task:collect-pools"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Pools"
 
     # Auxiliary task
     #
@@ -616,6 +619,12 @@ scheduler:
           - name: "openstack:model:router_external_ip"
             duration: 24h
           - name: "openstack:model:object"
+            duration: 24h
+          - name: "openstack:model:pool"
+            duration: 24h
+          - name: "openstack:model:pool_member"
+            duration: 24h
+          - name: "openstack:model:loadbalancer_with_pool"
             duration: 24h
           # Auxiliary
           - name: "aux:model:housekeeper_run"

--- a/internal/pkg/migrations/20250519161935_add_openstack_server_with_subnet.tx.down.sql
+++ b/internal/pkg/migrations/20250519161935_add_openstack_server_with_subnet.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_server_with_subnet";

--- a/internal/pkg/migrations/20250519161935_add_openstack_server_with_subnet.tx.up.sql
+++ b/internal/pkg/migrations/20250519161935_add_openstack_server_with_subnet.tx.up.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE VIEW "openstack_server_with_subnet" AS
+SELECT 
+    s.server_id,
+    s.name as server_name,
+    s.project_id,
+    s.domain,
+    s.region,
+    s.availability_zone,
+    s.status,
+    s.image_id,
+    s.server_created_at,
+    s.server_updated_at,
+    subnet.subnet_id,
+    subnet.name as subnet_name,
+    subnet.network_id,
+    subnet.gateway_ip,
+    subnet.subnet_pool_id,
+    subnet.enable_dhcp,
+    subnet.ip_version
+FROM openstack_server as s
+INNER JOIN openstack_port AS p ON s.server_id = p.device_id
+INNER JOIN openstack_port_ip AS pip ON p.port_id = pip.port_id
+INNER JOIN openstack_subnet AS subnet ON pip.subnet_id = subnet.subnet_id;

--- a/internal/pkg/migrations/20250522135239_add_openstack_pool.tx.down.sql
+++ b/internal/pkg/migrations/20250522135239_add_openstack_pool.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_pool";

--- a/internal/pkg/migrations/20250522135239_add_openstack_pool.tx.up.sql
+++ b/internal/pkg/migrations/20250522135239_add_openstack_pool.tx.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "openstack_pool" (
+    "pool_id" varchar NOT NULL,
+    "name" varchar NOT NULL,
+    "project_id" varchar NOT NULL,
+    "subnet_id" varchar NOT NULL,
+    "description" varchar NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_pool_key" UNIQUE ("pool_id", "project_id")
+);

--- a/internal/pkg/migrations/20250522162442_add_openstack_pool_member.tx.down.sql
+++ b/internal/pkg/migrations/20250522162442_add_openstack_pool_member.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_pool_member";

--- a/internal/pkg/migrations/20250522162442_add_openstack_pool_member.tx.up.sql
+++ b/internal/pkg/migrations/20250522162442_add_openstack_pool_member.tx.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "openstack_pool_member" (
+    "member_id" varchar NOT NULL,
+    "pool_id" varchar NOT NULL,
+    "project_id" varchar NOT NULL,
+    "name" varchar NOT NULL,
+    "subnet_id" varchar NOT NULL,
+    "protocol_port" varchar NOT NULL,
+    "member_created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "member_updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_pool_member_key" UNIQUE ("member_id", "pool_id", "project_id")
+);

--- a/internal/pkg/migrations/20250527135938_add_openstack_loadbalancer_with_pool.tx.down.sql
+++ b/internal/pkg/migrations/20250527135938_add_openstack_loadbalancer_with_pool.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_loadbalancer_with_pool";

--- a/internal/pkg/migrations/20250527135938_add_openstack_loadbalancer_with_pool.tx.up.sql
+++ b/internal/pkg/migrations/20250527135938_add_openstack_loadbalancer_with_pool.tx.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "openstack_loadbalancer_with_pool" (
+    "loadbalancer_id" varchar NOT NULL,
+    "pool_id" varchar NOT NULL,
+    "project_id" varchar NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_loadbalancer_with_pool_key" UNIQUE ("loadbalancer_id", "pool_id", "project_id")
+);

--- a/internal/pkg/migrations/20250528084144_add_openstack_router_with_port.tx.down.sql
+++ b/internal/pkg/migrations/20250528084144_add_openstack_router_with_port.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_router_with_port";

--- a/internal/pkg/migrations/20250528084144_add_openstack_router_with_port.tx.up.sql
+++ b/internal/pkg/migrations/20250528084144_add_openstack_router_with_port.tx.up.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW "openstack_router_with_port" AS
+SELECT
+    r.router_id,
+    r.name as router_name,
+    r.project_id,
+    r.domain,
+    r.region,
+    r.status as router_status,
+    r.description,
+    r.external_network_id,
+    r.created_at,
+    r.updated_at,
+    p.port_id,
+    pip.ip_address,
+    pip.subnet_id
+FROM openstack_router as r
+INNER JOIN openstack_port as p ON r.router_id = p.device_id
+INNER JOIN openstack_port_ip as pip on p.port_id = pip.port_id;

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -317,6 +317,19 @@ type PoolMember struct {
 	MemberUpdatedAt time.Time `bun:"member_updated_at,notnull"`
 }
 
+// LoadBalancerWithPool represents the connection between an OpenStack LoadBalancer and Pool
+// This is different to a link table in that it is populated during collection
+// and the pool ID is not a forein key in the Pool table, as the Pool record
+// might not exist yet.
+type LoadBalancerWithPool struct {
+	bun.BaseModel `bun:"table:openstack_loadbalancer_with_pool"`
+	coremodels.Model
+
+	LoadBalancerID string `bun:"loadbalancer_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	PoolID         string `bun:"pool_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	ProjectID      string `bun:"project_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+}
+
 func init() {
 	// Register the models with the default registry
 	registry.ModelRegistry.MustRegister("openstack:model:server", &Server{})

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -345,6 +345,7 @@ func init() {
 	registry.ModelRegistry.MustRegister("openstack:model:object", &Object{})
 	registry.ModelRegistry.MustRegister("openstack:model:pool", &Pool{})
 	registry.ModelRegistry.MustRegister("openstack:model:pool_member", &PoolMember{})
+	registry.ModelRegistry.MustRegister("openstack:model:loadbalancer_with_pool", &LoadBalancerWithPool{})
 
 	registry.ModelRegistry.MustRegister("openstack:model:link_subnet_to_network", &SubnetToNetwork{})
 	registry.ModelRegistry.MustRegister("openstack:model:link_loadbalancer_to_subnet", &LoadBalancerToSubnet{})

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -290,6 +290,33 @@ type Object struct {
 	IsLatest      bool      `bun:"is_latest,notnull"`
 }
 
+// Pool represents an OpenStack server Pool.
+type Pool struct {
+	bun.BaseModel `bun:"table:openstack_pool"`
+	coremodels.Model
+
+	PoolID      string `bun:"pool_id,notnull,unique:openstack_pool_key"`
+	ProjectID   string `bun:"project_id,notnull,unique:openstack_pool_key"`
+	Name        string `bun:"name,notnull"`
+	SubnetID    string `bun:"subnet_id,notnull"`
+	Description string `bun:"description,notnull"`
+}
+
+// PoolMember represents device that is a member of an OpenStack pool.
+type PoolMember struct {
+	bun.BaseModel `bun:"table:openstack_pool_member"`
+	coremodels.Model
+
+	MemberID        string    `bun:"member_id,notnull,unique:openstack_pool_member_key"`
+	PoolID          string    `bun:"pool_id,notnull,unique:openstack_pool_member_key"`
+	ProjectID       string    `bun:"project_id,notnull,unique:openstack_pool_member_key"`
+	Name            string    `bun:"name,notnull"`
+	SubnetID        string    `bun:"subnet_id,notnull"`
+	ProtocolPort    int       `bun:"protocol_port,notnull"`
+	MemberCreatedAt time.Time `bun:"member_created_at,notnull"`
+	MemberUpdatedAt time.Time `bun:"member_updated_at,notnull"`
+}
+
 func init() {
 	// Register the models with the default registry
 	registry.ModelRegistry.MustRegister("openstack:model:server", &Server{})
@@ -303,6 +330,8 @@ func init() {
 	registry.ModelRegistry.MustRegister("openstack:model:router", &Router{})
 	registry.ModelRegistry.MustRegister("openstack:model:router_external_ip", &RouterExternalIP{})
 	registry.ModelRegistry.MustRegister("openstack:model:object", &Object{})
+	registry.ModelRegistry.MustRegister("openstack:model:pool", &Pool{})
+	registry.ModelRegistry.MustRegister("openstack:model:pool_member", &PoolMember{})
 
 	registry.ModelRegistry.MustRegister("openstack:model:link_subnet_to_network", &SubnetToNetwork{})
 	registry.ModelRegistry.MustRegister("openstack:model:link_loadbalancer_to_subnet", &LoadBalancerToSubnet{})

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -315,6 +315,7 @@ type PoolMember struct {
 	ProtocolPort    int       `bun:"protocol_port,notnull"`
 	MemberCreatedAt time.Time `bun:"member_created_at,notnull"`
 	MemberUpdatedAt time.Time `bun:"member_updated_at,notnull"`
+	Pool            *Pool     `bun:"rel:has-one,join:project_id=project_id,join:pool_id=pool_id"`
 }
 
 // LoadBalancerWithPool represents the connection between an OpenStack LoadBalancer and Pool
@@ -325,9 +326,11 @@ type LoadBalancerWithPool struct {
 	bun.BaseModel `bun:"table:openstack_loadbalancer_with_pool"`
 	coremodels.Model
 
-	LoadBalancerID string `bun:"loadbalancer_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
-	PoolID         string `bun:"pool_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
-	ProjectID      string `bun:"project_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	LoadBalancerID string        `bun:"loadbalancer_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	PoolID         string        `bun:"pool_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	ProjectID      string        `bun:"project_id,notnull,unique:openstack_loadbalancer_with_pool_key"`
+	LoadBalancer   *LoadBalancer `bun:"rel:has-one,join:project_id=project_id,join:loadbalancer_id=loadbalancer_id"`
+	Pool           *Pool         `bun:"rel:has-one,join:project_id=project_id,join:pool_id=pool_id"`
 }
 
 func init() {

--- a/pkg/openstack/tasks/loadbalancers.go
+++ b/pkg/openstack/tasks/loadbalancers.go
@@ -240,7 +240,7 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 		"count", count,
 	)
 
-	if len(items) == 0 {
+	if len(lbWithPoolItems) == 0 {
 		return nil
 	}
 

--- a/pkg/openstack/tasks/loadbalancers.go
+++ b/pkg/openstack/tasks/loadbalancers.go
@@ -155,10 +155,10 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 
 				for _, lb := range lbList {
 					for _, pool := range lb.Pools {
-						item := models.LoadBalancerWithPool {
+						item := models.LoadBalancerWithPool{
 							LoadBalancerID: lb.ID,
-							PoolID: pool.ID,
-							ProjectID: lb.ProjectID,
+							PoolID:         pool.ID,
+							ProjectID:      lb.ProjectID,
 						}
 
 						lbWithPoolItems = append(lbWithPoolItems, item)

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -188,6 +188,16 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 								return true, nil
 							})
 
+					if err != nil {
+						logger.Error(
+							"could not insert pools into db",
+							"project", payload.Scope.Project,
+							"domain", payload.Scope.Domain,
+							"region", payload.Scope.Region,
+							"reason", err,
+						)
+					}
+
 					item := models.Pool{
 						PoolID:      pool.ID,
 						ProjectID:   pool.ProjectID,

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -190,12 +190,13 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 
 					if err != nil {
 						logger.Error(
-							"could not insert pools into db",
+							"could not extract pool member pages",
 							"project", payload.Scope.Project,
 							"domain", payload.Scope.Domain,
 							"region", payload.Scope.Region,
 							"reason", err,
 						)
+						return false, err
 					}
 
 					item := models.Pool{
@@ -215,6 +216,9 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 	if err != nil {
 		logger.Error(
 			"could not extract pool pages",
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
 			"reason", err,
 		)
 		return err

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/loadbalancer/v2/pools"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/hibiken/asynq"
+
+	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
+	"github.com/gardener/inventory/pkg/clients/db"
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+	"github.com/gardener/inventory/pkg/openstack/models"
+	openstackutils "github.com/gardener/inventory/pkg/openstack/utils"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// TaskCollectPools is the name of the task for collecting OpenStack
+	// Pools.
+	TaskCollectPools = "openstack:task:collect-pools"
+)
+
+// CollectPoolsPayload represents the payload, which specifies
+// where to collect OpenStack Pools from.
+type CollectPoolsPayload struct {
+	// Scope specifies the project scope to use for collection.
+	Scope openstackclients.ClientScope `json:"scope" yaml:"scope"`
+}
+
+// NewCollectPoolsTask creates a new [asynq.Task] for collecting OpenStack
+// Pools, without specifying a payload.
+func NewCollectPoolsTask() *asynq.Task {
+	return asynq.NewTask(TaskCollectPools, nil)
+}
+
+// HandleCollectPoolsTask handles the task for collecting OpenStack Pools.
+func HandleCollectPoolsTask(ctx context.Context, t *asynq.Task) error {
+	// If we were called without a payload, then we enqueue tasks for
+	// collecting OpenStack Pools for all configured clients.
+	data := t.Payload()
+	if data == nil {
+		return enqueueCollectPools(ctx)
+	}
+
+	var payload CollectPoolsPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if err := openstackutils.IsValidProjectScope(payload.Scope); err != nil {
+		return asynqutils.SkipRetry(ErrInvalidScope)
+	}
+
+	return collectPools(ctx, payload)
+}
+
+// enqueueCollectPools enqueues tasks for collecting OpenStack Pools from
+// all configured OpenStack clients by creating a payload with the respective
+// client scope.
+func enqueueCollectPools(ctx context.Context) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	if openstackclients.LoadBalancerClientset.Length() == 0 {
+		logger.Warn("no OpenStack loadbalancer clients found")
+		return nil
+	}
+
+	return openstackclients.LoadBalancerClientset.
+		Range(func(scope openstackclients.ClientScope, client openstackclients.Client[*gophercloud.ServiceClient]) error {
+			payload := CollectPoolsPayload{
+				Scope: scope,
+			}
+			data, err := json.Marshal(payload)
+			if err != nil {
+				logger.Error(
+					"failed to marshal payload for OpenStack pools",
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			task := asynq.NewTask(TaskCollectPools, data)
+			info, err := asynqclient.Client.Enqueue(task)
+			if err != nil {
+				logger.Error(
+					"failed to enqueue task",
+					"type", task.Type(),
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			logger.Info(
+				"enqueued task",
+				"type", task.Type(),
+				"id", info.ID,
+				"queue", info.Queue,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
+			)
+
+			return nil
+		})
+}
+
+// collectPools collects the OpenStack Pools,
+// using the client associated with the client scope in the given payload.
+func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	client, ok := openstackclients.LoadBalancerClientset.Get(payload.Scope)
+	if !ok {
+		return asynqutils.SkipRetry(ClientNotFound(payload.Scope.Project))
+	}
+
+	logger.Info(
+		"collecting OpenStack pools",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+	)
+
+	poolItems := make([]models.Pool, 0)
+	memberItems := make([]models.PoolMember, 0)
+
+	err := pools.List(client.Client, nil).
+		EachPage(ctx,
+			func(ctx context.Context, page pagination.Page) (bool, error) {
+				extractedPools, err := pools.ExtractPools(page)
+
+				if err != nil {
+					logger.Error(
+						"could not extract pool pages",
+						"project", payload.Scope.Project,
+						"domain", payload.Scope.Domain,
+						"region", payload.Scope.Region,
+						"reason", err,
+					)
+					return false, err
+				}
+
+				for _, pool := range extractedPools {
+					err = pools.ListMembers(client.Client, pool.ID, nil).
+						EachPage(ctx,
+							func(ctx context.Context, page pagination.Page) (bool, error) {
+								extractedMembers, err := pools.ExtractMembers(page)
+
+								if err != nil {
+									logger.Error(
+										"could not extract pool member pages",
+										"project", payload.Scope.Project,
+										"domain", payload.Scope.Domain,
+										"region", payload.Scope.Region,
+										"reason", err,
+									)
+									return false, err
+								}
+
+								for _, member := range extractedMembers {
+									item := models.PoolMember{
+										MemberID:        member.ID,
+										PoolID:          pool.ID,
+										ProjectID:       member.ProjectID,
+										Name:            member.Name,
+										SubnetID:        member.SubnetID,
+										ProtocolPort:    member.ProtocolPort,
+										MemberCreatedAt: member.CreatedAt,
+										MemberUpdatedAt: member.UpdatedAt,
+									}
+
+									memberItems = append(memberItems, item)
+								}
+
+								return true, nil
+							})
+
+					item := models.Pool{
+						PoolID:      pool.ID,
+						ProjectID:   pool.ProjectID,
+						Name:        pool.Name,
+						SubnetID:    pool.SubnetID,
+						Description: pool.Description,
+					}
+
+					poolItems = append(poolItems, item)
+				}
+
+				return true, nil
+			})
+
+	if err != nil {
+		logger.Error(
+			"could not extract pool pages",
+			"reason", err,
+		)
+		return err
+	}
+
+	if len(poolItems) == 0 {
+		return nil
+	}
+
+	out, err := db.DB.NewInsert().
+		Model(&poolItems).
+		On("CONFLICT (pool_id, project_id) DO UPDATE").
+		Set("name = EXCLUDED.name").
+		Set("subnet_id = EXCLUDED.subnet_id").
+		Set("description = EXCLUDED.description").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert pools into db",
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
+			"reason", err,
+		)
+		return err
+	}
+
+	count, err := out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated openstack pools",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+		"count", count,
+	)
+
+	if len(memberItems) == 0 {
+		return nil
+	}
+
+	out, err = db.DB.NewInsert().
+		Model(&memberItems).
+		On("CONFLICT (member_id, pool_id, project_id) DO UPDATE").
+		Set("name = EXCLUDED.name").
+		Set("subnet_id = EXCLUDED.subnet_id").
+		Set("protocol_port = EXCLUDED.protocol_port").
+		Set("member_created_at = EXCLUDED.member_created_at").
+		Set("member_updated_at = EXCLUDED.member_updated_at").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert pool members into db",
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
+			"reason", err,
+		)
+		return err
+	}
+
+	count, err = out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated openstack pool members",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+		"count", count,
+	)
+
+	return nil
+}

--- a/pkg/openstack/tasks/tasks.go
+++ b/pkg/openstack/tasks/tasks.go
@@ -41,6 +41,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectRoutersTask,
 		NewCollectPortsTask,
 		NewCollectObjectsTask,
+		NewCollectPoolsTask,
 	}
 
 	return asynqutils.Enqueue(ctx, taskFns, asynq.Queue(queue))
@@ -76,6 +77,7 @@ func init() {
 	registry.TaskRegistry.MustRegister(TaskCollectRouters, asynq.HandlerFunc(HandleCollectRoutersTask))
 	registry.TaskRegistry.MustRegister(TaskCollectPorts, asynq.HandlerFunc(HandleCollectPortsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectObjects, asynq.HandlerFunc(HandleCollectObjectsTask))
+	registry.TaskRegistry.MustRegister(TaskCollectPools, asynq.HandlerFunc(HandleCollectPoolsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
 	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Views:
- openstack_server_with_subnet - utility for mapping servers and subnets
- openstack_router_with_port - utility for mapping routers and ports
Tables:
- openstack_pool - represents OpenStack pools
- openstack_pool_member - represents OpenStack pool members (mapping is n:1 with servers)
- openstack_loadbalancer_with_pool - for the 1:n mapping between loadbalancers and pools

Tasks:
- OpenStack Pool/PoolMember collection. Those are in the same task, as members are extracted from pool instances.
- OpenStack LoadBalancerWithPool collection. It is implemented in the same task as LBs, since the information needed is in the OpenStack LB model.

** For reviewers **
Please give feedback especially on those particular things:
LoadBalancerWithPool - am I adding a model that can be skipped here? 
How can I map LB - Pools (1:n) in any other way? This looks like a link table, and in reality it is, but it's not populated during linking.
General - do I need to provide a better high level overview of how networking components are linked. Ideas how?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
OpenStack
- Models
Pool
PoolMember
LoadbalancerWithPool

- Views
openstack_router_with_port
openstack_server_with_subnet
```
