### PR TITLE
feat: metrics for the housekeeper

### DIFF
--- a/pkg/auxiliary/tasks/housekeeper.go
+++ b/pkg/auxiliary/tasks/housekeeper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gardener/inventory/pkg/auxiliary/models"
 	"github.com/gardener/inventory/pkg/clients/db"
 	"github.com/gardener/inventory/pkg/core/registry"
+	"github.com/gardener/inventory/pkg/metrics"
 	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
 )
 
@@ -90,10 +91,12 @@ func HandleHousekeeperTask(ctx context.Context, task *asynq.Task) error {
 				Count:       count,
 			}
 			hkRuns = append(hkRuns, hkRun)
+			metrics.HousekeeperDeletedRecords.WithLabelValues(item.Name).Set(float64(count))
 		default:
 			// Simply log the error here and keep going with the
 			// rest of the objects to cleanup
 			logger.Error("failed to delete stale records", "name", item.Name, "reason", err)
+			metrics.HousekeeperFailedRecordsTotal.WithLabelValues(item.Name).Inc()
 		}
 	}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -64,6 +64,17 @@ var (
 		},
 		[]string{"task_name", "task_queue"},
 	)
+
+	// HousekeeperDeletedRecords is a gauge, which tracks the number of
+	// deleted resources for models by the housekeeper.
+	HousekeeperDeletedRecords = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "housekeeper_deleted_records",
+			Help:      "Gauge which tracks the number of deleted records by the housekeeper",
+		},
+		[]string{"model_name"},
+	)
 )
 
 // NewServer returns a new [http.Server] which can serve the metrics from
@@ -93,6 +104,7 @@ func init() {
 		TaskFailedTotal,
 		TaskSkippedTotal,
 		TaskDurationSeconds,
+		HousekeeperDeletedRecords,
 
 		// Standard Go metrics
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -75,6 +75,18 @@ var (
 		},
 		[]string{"model_name"},
 	)
+
+	// HousekeeperFailedRecordsTotal is a metric, which gets incremented
+	// each time the housekeeper fails to delete stale records for a given
+	// model.
+	HousekeeperFailedRecordsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "housekeeper_failed_records_total",
+			Help:      "Total number of times the housekeeper failed to delete stale records",
+		},
+		[]string{"model_name"},
+	)
 )
 
 // NewServer returns a new [http.Server] which can serve the metrics from
@@ -105,6 +117,7 @@ func init() {
 		TaskSkippedTotal,
 		TaskDurationSeconds,
 		HousekeeperDeletedRecords,
+		HousekeeperFailedRecordsTotal,
 
 		// Standard Go metrics
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds two new metrics which track the successfully deleted records by the housekeeper, as well as the ones which have failed to be deleted.

New metrics:

- `inventory_housekeeper_deleted_records` gauge
- `inventory_housekeeper_failed_records_total` counter


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add metrics for the housekeeper
```
