### PR TITLE
feat: prometheus service discovery for workers and dashboard

### DIFF
--- a/deployment/kustomize/dashboard/deployment.yaml
+++ b/deployment/kustomize/dashboard/deployment.yaml
@@ -24,6 +24,11 @@ spec:
       labels:
         app: dashboard
         oidc-apps.gardener.cloud/name: dashboard
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/scheme: "http"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
     spec:
       containers:
       - name: dashboard

--- a/deployment/kustomize/prometheus/base/kustomization.yaml
+++ b/deployment/kustomize/prometheus/base/kustomization.yaml
@@ -12,3 +12,4 @@ generatorOptions:
 resources:
   - statefulset.yaml
   - service.yaml
+  - serviceaccount.yaml

--- a/deployment/kustomize/prometheus/base/kustomization.yaml
+++ b/deployment/kustomize/prometheus/base/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - statefulset.yaml
   - service.yaml
   - serviceaccount.yaml
+  - rbac.yaml

--- a/deployment/kustomize/prometheus/base/rbac.yaml
+++ b/deployment/kustomize/prometheus/base/rbac.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/part-of: inventory
+    app.kubernetes.io/managed-by: kustomize
+rules:
+- apiGroups:
+  - ""
+  resources:
+    - pods
+    - endpoints
+    - services
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+  - discovery.k8s.io/v1
+  resources:
+    - endpointslices
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/part-of: inventory
+    app.kubernetes.io/managed-by: kustomize
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus

--- a/deployment/kustomize/prometheus/base/serviceaccount.yaml
+++ b/deployment/kustomize/prometheus/base/serviceaccount.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus

--- a/deployment/kustomize/prometheus/base/statefulset.yaml
+++ b/deployment/kustomize/prometheus/base/statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: prometheus
       containers:
       - name: prometheus
         securityContext:

--- a/deployment/kustomize/prometheus/config/files/prometheus.yml
+++ b/deployment/kustomize/prometheus/config/files/prometheus.yml
@@ -51,7 +51,11 @@ scrape_configs:
   enable_http2: true
   kubernetes_sd_configs:
     - role: endpoints
-    - role: pods
+      namespaces:
+        own_namespace: true
+    - role: pod
+      namespaces:
+        own_namespace: true
   relabel_configs:
     - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
       action: keep

--- a/deployment/kustomize/prometheus/config/files/prometheus.yml
+++ b/deployment/kustomize/prometheus/config/files/prometheus.yml
@@ -70,6 +70,9 @@ scrape_configs:
       target_label: __address__
       regex: (.+)(?::\d+);(\d+)
       replacement: $1:$2
+    - source_labels: [ __meta_kubernetes_pod_container_init ]
+      regex: true
+      action: drop
     - source_labels: [__meta_kubernetes_namespace]
       action: replace
       target_label: kubernetes_namespace

--- a/deployment/kustomize/prometheus/config/files/prometheus.yml
+++ b/deployment/kustomize/prometheus/config/files/prometheus.yml
@@ -17,6 +17,7 @@ alerting:
     static_configs:
     - targets: []
 scrape_configs:
+# Prometheus jobs
 - job_name: prometheus
   honor_timestamps: true
   track_timestamps_staleness: false
@@ -34,6 +35,8 @@ scrape_configs:
   static_configs:
   - targets:
     - localhost:9090
+
+# Inventory jobs
 - job_name: inventory
   honor_timestamps: true
   track_timestamps_staleness: false
@@ -43,11 +46,35 @@ scrape_configs:
   - OpenMetricsText1.0.0
   - OpenMetricsText0.0.1
   - PrometheusText0.0.4
-  metrics_path: /metrics
-  scheme: http
   enable_compression: true
   follow_redirects: true
   enable_http2: true
-  static_configs:
-  - targets:
-    - dashboard:8080
+  kubernetes_sd_configs:
+    - role: endpoints
+    - role: pods
+  relabel_configs:
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      action: replace
+      target_label: __scheme__
+      regex: (https?)
+    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      action: replace
+      target_label: __address__
+      regex: (.+)(?::\d+);(\d+)
+      replacement: $1:$2
+    - source_labels: [__meta_kubernetes_namespace]
+      action: replace
+      target_label: kubernetes_namespace
+    - source_labels: [__meta_kubernetes_service_name]
+      action: replace
+      target_label: kubernetes_service
+    - source_labels: [__meta_kubernetes_pod_name]
+      action: replace
+      target_label: kubernetes_pod

--- a/deployment/kustomize/prometheus/config/files/prometheus.yml
+++ b/deployment/kustomize/prometheus/config/files/prometheus.yml
@@ -50,25 +50,22 @@ scrape_configs:
   follow_redirects: true
   enable_http2: true
   kubernetes_sd_configs:
-    - role: endpoints
-      namespaces:
-        own_namespace: true
     - role: pod
       namespaces:
         own_namespace: true
   relabel_configs:
-    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true
-    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
       action: replace
       target_label: __scheme__
       regex: (https?)
-    - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
       action: replace
       target_label: __metrics_path__
       regex: (.+)
-    - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
       action: replace
       target_label: __address__
       regex: (.+)(?::\d+);(\d+)
@@ -76,9 +73,6 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_namespace]
       action: replace
       target_label: kubernetes_namespace
-    - source_labels: [__meta_kubernetes_service_name]
-      action: replace
-      target_label: kubernetes_service
     - source_labels: [__meta_kubernetes_pod_name]
       action: replace
       target_label: kubernetes_pod

--- a/deployment/kustomize/worker/deployment.yaml
+++ b/deployment/kustomize/worker/deployment.yaml
@@ -22,6 +22,11 @@ spec:
     metadata:
       labels:
         app: worker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/scheme: "http"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "6080"
     spec:
       serviceAccountName: worker
       initContainers:

--- a/hack/update-kustomize-configs.sh
+++ b/hack/update-kustomize-configs.sh
@@ -20,8 +20,3 @@ install -m 0644 \
 rsync -av --exclude "*~" \
       "${_REPO_ROOT}/extra/grafana/" \
       "${_KUSTOMIZE_DIR}/grafana/config/files"
-
-# Update Prometheus configs
-install -m 0644 \
-        "${_REPO_ROOT}/extra/prometheus/prometheus.yml" \
-        "${_KUSTOMIZE_DIR}/prometheus/config/files/prometheus.yml"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR configures the provided Prometheus kustomization to use service discovery for worker and dashboard pods.

- Added service account for Prometheus STS
- Configured RBAC for Prometheus using a `ClusterRole` and `ClusterRoleBinding`, so that pods `pods`, `endpoints`, `endpointslices` and `services` can be discovered and watched
- Annotated the `worker` and `dashboard` pods in order to enable scraping for them

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: prometheus service discovery for worker and dashboard pods
```
