### PR TITLE
OpenStack orphan pools and pool members views

### DIFF
--- a/internal/pkg/migrations/20250530052448_update_openstack_pool_member_add_inferred_gardener_shoot.tx.down.sql
+++ b/internal/pkg/migrations/20250530052448_update_openstack_pool_member_add_inferred_gardener_shoot.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "openstack_pool_member" DROP COLUMN "inferred_gardener_shoot";

--- a/internal/pkg/migrations/20250530052448_update_openstack_pool_member_add_inferred_gardener_shoot.tx.up.sql
+++ b/internal/pkg/migrations/20250530052448_update_openstack_pool_member_add_inferred_gardener_shoot.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "openstack_pool_member" ADD COLUMN "inferred_gardener_shoot" VARCHAR;

--- a/internal/pkg/migrations/20250530093021_add_openstack_orphan_pool.tx.down.sql
+++ b/internal/pkg/migrations/20250530093021_add_openstack_orphan_pool.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_orphan_pool";

--- a/internal/pkg/migrations/20250530093021_add_openstack_orphan_pool.tx.up.sql
+++ b/internal/pkg/migrations/20250530093021_add_openstack_orphan_pool.tx.up.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW "openstack_orphan_pool" AS
+SELECT 
+    p.pool_id,
+    p.name,
+    p.project_id,
+    COUNT(pm.name) AS num_pool_members,
+    COUNT(s.name) AS num_servers
+FROM "openstack_pool" AS p
+    JOIN "openstack_pool_member" AS pm ON p.pool_id = pm.pool_id AND p.project_id = pm.project_id
+    LEFT JOIN "openstack_server" AS s ON pm.name = s.name AND pm.project_id = s.project_id
+    LEFT JOIN "g_shoot" AS gs ON pm.inferred_gardener_shoot = gs.technical_id
+GROUP BY p.name, p.pool_id, p.project_id
+HAVING bool_and(s.name IS NULL AND (gs.is_hibernated IS NULL or gs.is_hibernated = false));

--- a/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.down.sql
+++ b/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_orphan_pool_member";

--- a/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.up.sql
+++ b/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.up.sql
@@ -14,7 +14,3 @@ INNER JOIN openstack_pool AS p ON pm.project_id = p.project_id AND pm.pool_id = 
 LEFT JOIN openstack_server AS s ON pm.project_id = s.project_id AND pm.name = s.name
 LEFT JOIN g_shoot AS gs ON pm.inferred_gardener_shoot = gs.technical_id
 WHERE s.name IS NULL AND (gs.is_hibernated IS NULL OR gs.is_hibernated = false);
-
--- INNER JOIN openstack_pool AS p ON pm.project_id = p.project_id AND pm.pool_id = p.pool_id
--- LEFT JOIN openstack_server AS s ON pm.project_id = s.project_id AND pm.name = s.name
--- WHERE s.name IS NULL;

--- a/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.up.sql
+++ b/internal/pkg/migrations/20250604073850_add_openstack_orphan_pool_member.tx.up.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE VIEW "openstack_orphan_pool_member" AS
+SELECT
+    p.pool_id,
+    p.name as pool_name,
+    p.project_id,
+    pm.member_id,
+    pm.name,
+    pm.inferred_gardener_shoot,
+    pm.protocol_port,
+    pm.member_created_at,
+    pm.member_updated_at
+FROM openstack_pool_member AS pm
+INNER JOIN openstack_pool AS p ON pm.project_id = p.project_id AND pm.pool_id = p.pool_id
+LEFT JOIN openstack_server AS s ON pm.project_id = s.project_id AND pm.name = s.name
+LEFT JOIN g_shoot AS gs ON pm.inferred_gardener_shoot = gs.technical_id
+WHERE s.name IS NULL AND (gs.is_hibernated IS NULL OR gs.is_hibernated = false);
+
+-- INNER JOIN openstack_pool AS p ON pm.project_id = p.project_id AND pm.pool_id = p.pool_id
+-- LEFT JOIN openstack_server AS s ON pm.project_id = s.project_id AND pm.name = s.name
+-- WHERE s.name IS NULL;

--- a/pkg/gardener/utils/utils.go
+++ b/pkg/gardener/utils/utils.go
@@ -46,7 +46,7 @@ var ErrCannotInferShoot = errors.New("cannot infer shoot")
 // SHA-256 digest.
 //
 // Use this utility function to infer shoot details for Virtual Machines
-// provisioned by the GCP, AWS or Azure extensions only.
+// provisioned by the GCP, AWS, Azure or OpenStack extensions only.
 func InferShootFromInstanceName(ctx context.Context, name string) (*models.Shoot, error) {
 	pattern := regexp.MustCompile("^shoot--(?P<project>.*)--(?P<shoot_and_workerpool>.*)-z(?P<zone_index>.)-(?P<pool_hash>.{5})-(?P<vm_hash>.{5})$")
 	matches := pattern.FindStringSubmatch(name)

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -307,15 +307,16 @@ type PoolMember struct {
 	bun.BaseModel `bun:"table:openstack_pool_member"`
 	coremodels.Model
 
-	MemberID        string    `bun:"member_id,notnull,unique:openstack_pool_member_key"`
-	PoolID          string    `bun:"pool_id,notnull,unique:openstack_pool_member_key"`
-	ProjectID       string    `bun:"project_id,notnull,unique:openstack_pool_member_key"`
-	Name            string    `bun:"name,notnull"`
-	SubnetID        string    `bun:"subnet_id,notnull"`
-	ProtocolPort    int       `bun:"protocol_port,notnull"`
-	MemberCreatedAt time.Time `bun:"member_created_at,notnull"`
-	MemberUpdatedAt time.Time `bun:"member_updated_at,notnull"`
-	Pool            *Pool     `bun:"rel:has-one,join:project_id=project_id,join:pool_id=pool_id"`
+	MemberID              string    `bun:"member_id,notnull,unique:openstack_pool_member_key"`
+	PoolID                string    `bun:"pool_id,notnull,unique:openstack_pool_member_key"`
+	ProjectID             string    `bun:"project_id,notnull,unique:openstack_pool_member_key"`
+	Name                  string    `bun:"name,notnull"`
+	InferredGardenerShoot string    `bun:"inferred_gardener_shoot,nullzero"`
+	SubnetID              string    `bun:"subnet_id,notnull"`
+	ProtocolPort          int       `bun:"protocol_port,notnull"`
+	MemberCreatedAt       time.Time `bun:"member_created_at,notnull"`
+	MemberUpdatedAt       time.Time `bun:"member_updated_at,notnull"`
+	Pool                  *Pool     `bun:"rel:has-one,join:project_id=project_id,join:pool_id=pool_id"`
 }
 
 // LoadBalancerWithPool represents the connection between an OpenStack LoadBalancer and Pool


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the following views:
- openstack_orphan_pool
- openstack_orphan_pool_member

Adds InferredGardenerShoot field to the OpenStackPoolMember model, so we can link to shoots like with the other providers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
openstack_orphan_pool, openstack_orphan_pool_member
```
