### PR TITLE
OpenStack Containers (+ disable Object collection)

### DIFF
--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -505,6 +505,9 @@ scheduler:
     - name: "openstack:task:collect-pools"
       spec: "@every 1h"
       desc: "Collect OpenStack Pools"
+    - name: "openstack:task:collect-containers"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Containers"
 
     # Auxiliary task
     #

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -26,6 +26,11 @@ database:
 
 # Worker settings
 worker:
+  # Metrics settings
+  metrics:
+    path: /metrics
+    address: ":6080"
+
   # Concurrency level
   concurrency: 100
 
@@ -44,6 +49,7 @@ worker:
   # higher priority queues are empty.
   strict_priority: false
 
+# Dashboard settings
 dashboard:
   address: ":8080"
   read_only: false
@@ -318,7 +324,7 @@ openstack:
       use_credentials:
         - local
         - sa2
-    # Used for collecting OpenStack Objects
+    # Used for collecting OpenStack Containers and Objects
     object_storage:
       use_credentials:
         - sa1
@@ -493,9 +499,9 @@ scheduler:
     - name: "openstack:task:collect-routers"
       spec: "@every 1h"
       desc: "Collect OpenStack Routers"
-    - name: "openstack:task:collect-objects"
-      spec: "@every 1h"
-      desc: "Collect OpenStack Objects"
+    # - name: "openstack:task:collect-objects"
+    #   spec: "@every 1h"
+    #   desc: "Collect OpenStack Objects"
     - name: "openstack:task:collect-pools"
       spec: "@every 1h"
       desc: "Collect OpenStack Pools"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -324,7 +324,7 @@ openstack:
       use_credentials:
         - local
         - sa2
-    # Used for collecting OpenStack Objects
+    # Used for collecting OpenStack Containers and Objects
     object_storage:
       use_credentials:
         - sa1
@@ -499,9 +499,9 @@ scheduler:
     - name: "openstack:task:collect-routers"
       spec: "@every 1h"
       desc: "Collect OpenStack Routers"
-    - name: "openstack:task:collect-objects"
-      spec: "@every 1h"
-      desc: "Collect OpenStack Objects"
+    # - name: "openstack:task:collect-objects"
+    #   spec: "@every 1h"
+    #   desc: "Collect OpenStack Objects"
     - name: "openstack:task:collect-pools"
       spec: "@every 1h"
       desc: "Collect OpenStack Pools"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -505,6 +505,9 @@ scheduler:
     - name: "openstack:task:collect-pools"
       spec: "@every 1h"
       desc: "Collect OpenStack Pools"
+    - name: "openstack:task:collect-containers"
+      spec: "@every 1h"
+      desc: "Collect OpenStack Containers"
 
     # Auxiliary task
     #

--- a/internal/pkg/migrations/20250605085431_add_openstack_container.tx.down.sql
+++ b/internal/pkg/migrations/20250605085431_add_openstack_container.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_container";

--- a/internal/pkg/migrations/20250605085431_add_openstack_container.tx.up.sql
+++ b/internal/pkg/migrations/20250605085431_add_openstack_container.tx.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "openstack_container" (
+    "name" varchar NOT NULL,
+    "project_id" varchar NOT NULL,
+    "bytes" bigint NOT NULL,
+    "object_count" bigint NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY ("id"),
+    CONSTRAINT "openstack_container_key" UNIQUE ("name", "project_id")
+);

--- a/internal/pkg/migrations/20250605091414_add_openstack_orphan_container.tx.down.sql
+++ b/internal/pkg/migrations/20250605091414_add_openstack_orphan_container.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_orphan_container";

--- a/internal/pkg/migrations/20250605091414_add_openstack_orphan_container.tx.up.sql
+++ b/internal/pkg/migrations/20250605091414_add_openstack_orphan_container.tx.up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE VIEW "openstack_orphan_container" AS
+SELECT
+    c.name,
+    c.project_id,
+    c.bytes,
+    c.object_count,
+    c.created_at,
+    c.updated_at
+FROM openstack_container AS c
+LEFT JOIN g_backup_bucket gbb ON c.name = gbb.name AND gbb.provider_type = 'openstack'
+WHERE gbb.name IS NULL;

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -277,6 +277,17 @@ type RouterExternalIP struct {
 	Project          *Project `bun:"rel:has-one,join:project_id=project_id"`
 }
 
+// Container represents an OpenStack Container.
+type Container struct {
+	bun.BaseModel `bun:"table:openstack_container"`
+	coremodels.Model
+
+	Name        string `bun:"name,notnull,unique:openstack_container_key"`
+	ProjectID   string `bun:"project_id,notnull,unique:openstack_container_key"`
+	Bytes       int64  `bun:"bytes,notnull"`
+	ObjectCount int64  `bun:"object_count,notnull"`
+}
+
 // Object represents an OpenStack Object.
 type Object struct {
 	bun.BaseModel `bun:"table:openstack_object"`
@@ -347,6 +358,7 @@ func init() {
 	registry.ModelRegistry.MustRegister("openstack:model:router", &Router{})
 	registry.ModelRegistry.MustRegister("openstack:model:router_external_ip", &RouterExternalIP{})
 	registry.ModelRegistry.MustRegister("openstack:model:object", &Object{})
+	registry.ModelRegistry.MustRegister("openstack:model:container", &Container{})
 	registry.ModelRegistry.MustRegister("openstack:model:pool", &Pool{})
 	registry.ModelRegistry.MustRegister("openstack:model:pool_member", &PoolMember{})
 	registry.ModelRegistry.MustRegister("openstack:model:loadbalancer_with_pool", &LoadBalancerWithPool{})

--- a/pkg/openstack/tasks/containers.go
+++ b/pkg/openstack/tasks/containers.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/objectstorage/v1/containers"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+	"github.com/hibiken/asynq"
+
+	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
+	"github.com/gardener/inventory/pkg/clients/db"
+	openstackclients "github.com/gardener/inventory/pkg/clients/openstack"
+	"github.com/gardener/inventory/pkg/openstack/models"
+	openstackutils "github.com/gardener/inventory/pkg/openstack/utils"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// TaskCollectContainers is the name of the task for collecting OpenStack
+	// Containers.
+	TaskCollectContainers = "openstack:task:collect-containers"
+)
+
+// CollectContainersPayload represents the payload, which specifies
+// where to collect OpenStack Containers from.
+type CollectContainersPayload struct {
+	// Scope specifies the client scope for which to collect.
+	Scope openstackclients.ClientScope `json:"scope" yaml:"scope"`
+}
+
+// NewCollectContainersTask creates a new [asynq.Task] for collecting OpenStack
+// Containers, without specifying a payload.
+func NewCollectContainersTask() *asynq.Task {
+	return asynq.NewTask(TaskCollectContainers, nil)
+}
+
+// HandleCollectContainersTask handles the task for collecting OpenStack Containers.
+func HandleCollectContainersTask(ctx context.Context, t *asynq.Task) error {
+	// If we were called without a payload, then we enqueue tasks for
+	// collecting OpenStack Containers from all configured object clients.
+	data := t.Payload()
+	if data == nil {
+		return enqueueCollectContainers(ctx)
+	}
+
+	var payload CollectContainersPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if err := openstackutils.IsValidProjectScope(payload.Scope); err != nil {
+		return asynqutils.SkipRetry(ErrInvalidScope)
+	}
+
+	return collectContainers(ctx, payload)
+}
+
+// enqueueCollectContainers enqueues tasks for collecting OpenStack Containers from
+// all configured OpenStack Container clients by creating a payload with the respective
+// client scope.
+func enqueueCollectContainers(ctx context.Context) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	if openstackclients.ObjectStorageClientset.Length() == 0 {
+		logger.Warn("no OpenStack object storage clients found")
+		return nil
+	}
+
+	queue := asynqutils.GetQueueName(ctx)
+
+	return openstackclients.ObjectStorageClientset.
+		Range(func(scope openstackclients.ClientScope, client openstackclients.Client[*gophercloud.ServiceClient]) error {
+			payload := CollectContainersPayload{
+				Scope: scope,
+			}
+			data, err := json.Marshal(payload)
+			if err != nil {
+				logger.Error(
+					"failed to marshal payload for OpenStack containers",
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			task := asynq.NewTask(TaskCollectContainers, data)
+			info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
+			if err != nil {
+				logger.Error(
+					"failed to enqueue task",
+					"type", task.Type(),
+					"project", scope.Project,
+					"domain", scope.Domain,
+					"region", scope.Region,
+					"reason", err,
+				)
+				return err
+			}
+
+			logger.Info(
+				"enqueued task",
+				"type", task.Type(),
+				"id", info.ID,
+				"queue", info.Queue,
+				"project", scope.Project,
+				"domain", scope.Domain,
+				"region", scope.Region,
+			)
+
+			return nil
+		})
+}
+
+// collectContainer collects the OpenStack Containers,
+// using the client associated with the client scope in the given payload.
+func collectContainers(ctx context.Context, payload CollectContainersPayload) error {
+	logger := asynqutils.GetLogger(ctx)
+
+	client, ok := openstackclients.ObjectStorageClientset.Get(payload.Scope)
+	if !ok {
+		return asynqutils.SkipRetry(ClientNotFound(payload.Scope.Project))
+	}
+
+	logger.Info(
+		"collecting OpenStack containers",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+	)
+
+	items := make([]models.Container, 0)
+
+	projects, err := openstackutils.GetResourcesFromDB[models.Project](ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not get projects from db",
+			"reason", err,
+		)
+		return err
+	}
+
+	err = containers.List(client.Client, nil).
+		EachPage(ctx,
+			func(ctx context.Context, page pagination.Page) (bool, error) {
+				extractedContainers, err := containers.ExtractInfo(page)
+				if err != nil {
+					logger.Error(
+						"could not extract container pages",
+						"reason", err,
+					)
+					return false, err
+				}
+
+				for _, container := range extractedContainers {
+					project, err := openstackutils.MatchScopeToProject(client.ClientScope, projects)
+					if err != nil {
+						logger.Error(
+							"could not get project for container",
+							"reason", err,
+						)
+					}
+
+					item := models.Container{
+						Name:        container.Name,
+						ProjectID:   project.ProjectID,
+						Bytes:       container.Bytes,
+						ObjectCount: container.Count,
+					}
+
+					items = append(items, item)
+				}
+
+				return true, nil
+			})
+
+	if err != nil {
+		logger.Error(
+			"could not extract container pages",
+			"reason", err,
+		)
+		return err
+	}
+
+	if len(items) == 0 {
+		return nil
+	}
+
+	out, err := db.DB.NewInsert().
+		Model(&items).
+		On("CONFLICT (name, project_id) DO UPDATE").
+		Set("bytes = EXCLUDED.bytes").
+		Set("object_count = EXCLUDED.object_count").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert containers into db",
+			"project", payload.Scope.Project,
+			"domain", payload.Scope.Domain,
+			"region", payload.Scope.Region,
+			"reason", err,
+		)
+		return err
+	}
+
+	count, err := out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated openstack containers",
+		"project", payload.Scope.Project,
+		"domain", payload.Scope.Domain,
+		"region", payload.Scope.Region,
+		"count", count,
+	)
+
+	return nil
+}

--- a/pkg/openstack/tasks/projects.go
+++ b/pkg/openstack/tasks/projects.go
@@ -118,7 +118,7 @@ func enqueueCollectProjects(ctx context.Context) error {
 	})
 }
 
-// collectProjects collects the OpenStack Projects from the specified project,
+// collectProjects collects the OpenStack Projects,
 // using the identity client associated with the project ID in the given payload.
 func collectProjects(ctx context.Context, payload CollectProjectsPayload) error {
 	logger := asynqutils.GetLogger(ctx)

--- a/pkg/openstack/tasks/tasks.go
+++ b/pkg/openstack/tasks/tasks.go
@@ -42,6 +42,7 @@ func HandleCollectAllTask(ctx context.Context, t *asynq.Task) error {
 		NewCollectPortsTask,
 		NewCollectObjectsTask,
 		NewCollectPoolsTask,
+		NewCollectContainersTask,
 	}
 
 	return asynqutils.Enqueue(ctx, taskFns, asynq.Queue(queue))
@@ -78,6 +79,7 @@ func init() {
 	registry.TaskRegistry.MustRegister(TaskCollectPorts, asynq.HandlerFunc(HandleCollectPortsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectObjects, asynq.HandlerFunc(HandleCollectObjectsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectPools, asynq.HandlerFunc(HandleCollectPoolsTask))
+	registry.TaskRegistry.MustRegister(TaskCollectContainers, asynq.HandlerFunc(HandleCollectContainersTask))
 	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
 	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
 }

--- a/pkg/openstack/utils/utils.go
+++ b/pkg/openstack/utils/utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gardener/inventory/pkg/openstack/models"
 )
 
-// ErrProjectNotFound is an error which is returned when the task for finding
+// ErrNoProjectMatchingScope is an error which is returned when the task for finding
 // [models.Project] project by client scope doesn't find a match.
 var ErrNoProjectMatchingScope = errors.New("no project matching scope found")
 

--- a/pkg/utils/asynq/middlewares.go
+++ b/pkg/utils/asynq/middlewares.go
@@ -11,8 +11,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/gardener/inventory/pkg/metrics"
 	"github.com/hibiken/asynq"
+
+	"github.com/gardener/inventory/pkg/metrics"
 )
 
 // NewLoggerMiddleware returns a new [asynq.MiddlewareFunc], which embeds a


### PR DESCRIPTION
**What this PR does / why we need it**:
Add task for collecting OpenStack Containers, which are the Gardener Bucket equivalent in our OpenStack implementation.
DB:
- openstack_container
- openstack_orphan_container (view)
Model:
Container
Task:
openstack:task:collect-containers

Also, disable openstack:task:collect-objects in example config, since the records are too many and currently not needed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
OpenStack Containers
```
