### PR TITLE
Fix OpenStack orphan views

### DIFF
--- a/internal/pkg/migrations/20250617123040_fix_openstack_orphan_loadbalancer.tx.down.sql
+++ b/internal/pkg/migrations/20250617123040_fix_openstack_orphan_loadbalancer.tx.down.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS "openstack_orphan_loadbalancer";
+
+CREATE OR REPLACE VIEW "openstack_orphan_loadbalancer" AS
+SELECT
+    lb.id,
+    lb.name,
+    lb.status,
+    lb.provider,
+    lb.vip_address,
+    lb.vip_network_id,
+    lb.vip_subnet_id,
+    lb.loadbalancer_created_at,
+    lb.loadbalancer_updated_at,
+    lb.project_id
+FROM openstack_loadbalancer as lb
+LEFT JOIN openstack_orphan_network as n
+ON lb.vip_network_id = n.network_id
+WHERE n.network_id IS NULL;

--- a/internal/pkg/migrations/20250617123040_fix_openstack_orphan_loadbalancer.tx.up.sql
+++ b/internal/pkg/migrations/20250617123040_fix_openstack_orphan_loadbalancer.tx.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS "openstack_orphan_loadbalancer";
+
+CREATE OR REPLACE VIEW "openstack_orphan_loadbalancer" AS
+SELECT
+    lb.loadbalancer_id,
+    lb.name,
+    lb.status,
+    lb.provider,
+    lb.vip_address,
+    lb.vip_network_id,
+    lb.vip_subnet_id,
+    lb.loadbalancer_created_at,
+    lb.loadbalancer_updated_at,
+    lb.project_id
+FROM openstack_loadbalancer as lb
+LEFT JOIN openstack_network as n
+ON lb.vip_network_id = n.network_id
+WHERE n.network_id IS NULL
+OR n.network_id IN (SELECT network_id FROM openstack_orphan_network);

--- a/internal/pkg/migrations/20250617130939_fix_openstack_orphan_floating_ip.tx.down.sql
+++ b/internal/pkg/migrations/20250617130939_fix_openstack_orphan_floating_ip.tx.down.sql
@@ -1,0 +1,14 @@
+DROP VIEW IF EXISTs "openstack_orphan_floating_ip";
+
+CREATE OR REPLACE VIEW "openstack_orphan_floating_ip" AS
+SELECT
+    ip.id,
+    ip.fixed_ip,
+    ip.floating_ip,
+    ip.floating_network_id,
+    ip.ip_created_at,
+    ip.ip_updated_at,
+    ip.project_id
+FROM openstack_floating_ip as ip
+JOIN openstack_orphan_network as n
+ON ip.floating_network_id = n.network_id;

--- a/internal/pkg/migrations/20250617130939_fix_openstack_orphan_floating_ip.tx.up.sql
+++ b/internal/pkg/migrations/20250617130939_fix_openstack_orphan_floating_ip.tx.up.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS "openstack_orphan_floating_ip";
+
+CREATE OR REPLACE VIEW "openstack_orphan_floating_ip" AS
+SELECT
+    fip.floating_ip_id,
+    fip.project_id AS ip_project_id,
+    fip.domain AS ip_domain,
+    fip.region AS ip_region,
+    fip.port_id,
+    fip.router_id,
+    fip.project_id,
+    p.device_id,
+    lb.loadbalancer_id,
+    lb.name AS loadbalancer_name
+FROM openstack_floating_ip AS fip
+JOIN openstack_port AS p ON fip.port_id = p.port_id AND fip.project_id = p.project_id
+LEFT JOIN openstack_loadbalancer AS lb ON p.device_id = lb.loadbalancer_id
+WHERE lb.id IS NULL OR lb.loadbalancer_id IN (SELECT olb.loadbalancer_id FROM openstack_orphan_loadbalancer olb);


### PR DESCRIPTION
Fix the following Openstack orphan views:
- openstack_orphan_loadbalancer
- openstack_orphan_floating_ip

Floating IPs were completely wrong, while LBs better represent the 'orphaned' state now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
