### PR TITLE
feat: support for creating OpenStack API clients from Vault secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ dev/local/postgres
 dev/local/valkey
 dev/local/redis
 dev/local/prometheus
+dev/local/vault
 
 # direnv
 .envrc

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -66,20 +66,35 @@ func validateOpenStackConfig(conf *config.Config) error {
 		switch creds.Authentication {
 		case config.OpenStackAuthenticationMethodPassword:
 			if creds.Password.Username == "" {
-				return fmt.Errorf("OpenStack: %w: %s", errNoUsername, name)
+				return fmt.Errorf("openstack: %w: %s", errNoUsername, name)
 			}
 			if creds.Password.PasswordFile == "" {
-				return fmt.Errorf("OpenStack: %w: %s", errNoPasswordFile, name)
+				return fmt.Errorf("openstack: %w: %s", errNoPasswordFile, name)
 			}
 		case config.OpenStackAuthenticationMethodAppCredentials:
 			if creds.AppCredentials.AppCredentialsID == "" {
-				return fmt.Errorf("OpenStack: %w: %s", errNoAppCredentialsID, name)
+				return fmt.Errorf("openstack: %w: %s", errNoAppCredentialsID, name)
 			}
 			if creds.AppCredentials.AppCredentialsSecretFile == "" {
-				return fmt.Errorf("OpenStack: %w: %s", errNoAppCredentialsSecretFile, name)
+				return fmt.Errorf("openstack: %w: %s", errNoAppCredentialsSecretFile, name)
+			}
+		case config.OpenStackAuthenticationMethodVaultSecret:
+			if creds.VaultSecret.Server == "" {
+				return fmt.Errorf("openstack: no vault server specified for %s", name)
+			}
+
+			if _, ok := conf.Vault.Servers[creds.VaultSecret.Server]; !ok {
+				return fmt.Errorf("openstack: %s refers to unknown vault server %s", name, creds.VaultSecret.Server)
+			}
+
+			if creds.VaultSecret.SecretEngine == "" {
+				return fmt.Errorf("openstack: no vault secret engine specified for %s", name)
+			}
+			if creds.VaultSecret.SecretPath == "" {
+				return fmt.Errorf("openstack: no vault secret path specified for %s", name)
 			}
 		default:
-			return fmt.Errorf("OpenStack: %w: %s uses %s", errUnknownAuthenticationMethod, name, creds.Authentication)
+			return fmt.Errorf("openstack: %w: %s uses %s", errUnknownAuthenticationMethod, name, creds.Authentication)
 		}
 	}
 
@@ -93,11 +108,11 @@ func validateOpenStackConfig(conf *config.Config) error {
 		// Validate that the named credentials are actually defined.
 		for _, cred := range credentials {
 			if cred == "" {
-				return fmt.Errorf("OpenStack: %w: %s", errNoServiceCredentials, service)
+				return fmt.Errorf("openstack: %w: %s", errNoServiceCredentials, service)
 			}
 
 			if _, ok := conf.OpenStack.Credentials[cred]; !ok {
-				return fmt.Errorf("OpenStack: %w: service %s refers to %s", errUnknownNamedCredentials, service, cred)
+				return fmt.Errorf("openstack: %w: service %s refers to %s", errUnknownNamedCredentials, service, cred)
 			}
 		}
 	}

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/v2"
@@ -154,7 +155,7 @@ func newOpenStackProviderClient(
 			return nil, fmt.Errorf("no username specified for project %s", creds.Project)
 		}
 
-		rawPassword, err := os.ReadFile(creds.Password.PasswordFile)
+		rawPassword, err := os.ReadFile(filepath.Clean(creds.Password.PasswordFile))
 		if err != nil {
 			return nil, fmt.Errorf("unable to read password file: %w", err)
 		}
@@ -177,7 +178,7 @@ func newOpenStackProviderClient(
 			return nil, fmt.Errorf("no app credentials id specified for project %s", creds.Project)
 		}
 
-		rawAppSecret, err := os.ReadFile(creds.AppCredentials.AppCredentialsSecretFile)
+		rawAppSecret, err := os.ReadFile(filepath.Clean(creds.AppCredentials.AppCredentialsSecretFile))
 		if err != nil {
 			return nil, fmt.Errorf("unable to read app credentials secret file: %w", err)
 		}

--- a/cmd/inventory/utils_openstack.go
+++ b/cmd/inventory/utils_openstack.go
@@ -209,7 +209,11 @@ func configureOpenStackServiceClientset(
 	conf *config.Config,
 	serviceFunc func(providerClient *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error)) error {
 	for _, credentials := range serviceConfig.UseCredentials {
-		namedCreds := conf.OpenStack.Credentials[credentials]
+		namedCreds, ok := conf.OpenStack.Credentials[credentials]
+		if !ok {
+			return fmt.Errorf("openstack: %w: %q", errUnknownNamedCredentials, credentials)
+		}
+
 		providerClient, err := newOpenStackProviderClient(ctx, &namedCreds)
 
 		if err != nil {

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -16,6 +16,7 @@ logging:
   # attributes:
   #   landscape: dev
 
+# Redis/Valkey settings
 redis:
   endpoint: valkey:6379
 
@@ -23,6 +24,74 @@ redis:
 database:
   dsn: "postgresql://inventory:p4ssw0rd@postgres:5432/inventory?sslmode=disable"
   migration_dir: ./internal/pkg/migrations
+
+# Vault settings.
+#
+# Some datasources such as OpenStack may be configured from Vault
+# secrets. Please refer to the respective datasource configuration (e.g. GCP,
+# Azure, AWS, etc.) for more details whether named credentials may be configured
+# using secrets from Vault.
+#
+# When `vault.is_enabled' is set to true, then Inventory will create Vault API
+# clients to the specified Vault servers, which can later be used to construct
+# other datasource API clients from Vault secrets (e.g. OpenStack credentials)
+# or the Vault API clients may be used during task execution.
+vault:
+  is_enabled: false
+
+  # The Vault servers for which API clients will be created.
+  servers:
+    # Dev Vault server example
+    vault-dev:
+      # Endpoint of the Vault server
+      endpoint: http://localhost:8200/
+
+      # Optional TLS settings
+      # tls:
+      #   ca_cert: /path/to/ca.crt
+      #   ca_cert_bytes: "PEM-encoded CA bundle"
+      #   ca_path: /path/to/ca/cert/files
+      #   client_cert: /path/to/client.crt
+      #   client_key: /path/to/client.key
+      #   tls_server_name: SNI-host
+      #   insecure: false
+
+      # The supported Auth Methods are `token' and `jwt'.
+      auth_method: token
+
+      # Auth settings when using `token' auth method.
+      token_auth:
+        token_path: /path/to/my/token
+
+    # # Production Vault server example
+    # vault-prod:
+    #   # Endpoint of the Vault server
+    #   endpoint: https://vault.example.org:8200/
+
+    #   # Vault namespace
+    #   namespace: my-vault-namespace
+
+    #   # Optional TLS settings
+    #   # tls:
+    #   #   ca_cert: /path/to/ca.crt
+    #   #   ca_cert_bytes: "PEM-encoded CA bundle"
+    #   #   ca_path: /path/to/ca/cert/files
+    #   #   client_cert: /path/to/client.crt
+    #   #   client_key: /path/to/client.key
+    #   #   tls_server_name: SNI-host
+    #   #   insecure: false
+
+    #   # Example of `jwt' Auth Method
+    #   auth_method: jwt
+
+    #   # Auth settings when using `jwt' auth method.
+    #   jwt_auth:
+    #     # Mount path of the JWT Auth Method
+    #     mount_path: my-jwt-am-mount-path
+    #     # Role name to use
+    #     role_name: my-role-name
+    #     # Path to a JWT token to use for logging into Vault
+    #     token_path: /path/to/my/jwt/token
 
 # Worker settings
 worker:
@@ -279,13 +348,17 @@ aws:
         role_arn: arn:aws:iam::account:role/name
         role_session_name: gardener-inventory-worker
 
+# OpenStack specific configuration
 openstack:
   is_enabled: false
 
   # The `credentials' section provides named credentials, which are used by the
-  # various OpenStack services. The currently supported authentication mechanisms are `password' for username and password
-  # and `app_credentials' for application credentials.
+  # various OpenStack services. The currently supported authentication
+  # mechanisms are `password' for username and password, `app_credentials' for
+  # Application Credentials and `vault_secret' for credentials provided by a
+  # Vault secret..
   credentials:
+    # Example of using username/password for authentication
     local:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -295,6 +368,7 @@ openstack:
       password:
         username: "<username>"
         password_file: "<path-to-password-file>"
+    # Example of using Application Credentials for authentication
     sa1:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -313,6 +387,23 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    sa3:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
+      authentication: vault_secret
+      vault_secret:
+        # Must refer to a server already defined in `vault.servers'
+        server: vault-dev
+
+        # Mount point of a KV v2 secret engine
+        secret_engine: kvv2
+
+        # Path to the secret
+        secret_path: my/secret
+
+  # OpenStack services configuration
   services:
     # Used for collecting OpenStack Servers
     compute:

--- a/deployment/kustomize/config/secrets/config.yaml
+++ b/deployment/kustomize/config/secrets/config.yaml
@@ -378,6 +378,7 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    # Another Application Credentials example
     sa2:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -387,6 +388,7 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    # Example of using a Vault secret
     sa3:
       domain: <domain>
       auth_endpoint: <endpoint>

--- a/deployment/kustomize/grafana/config/files/dashboards/inventory/inventory-leaked-openstack.json
+++ b/deployment/kustomize/grafana/config/files/dashboards/inventory/inventory-leaked-openstack.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 27,
+  "id": 9,
   "links": [],
   "panels": [
     {
@@ -31,1565 +31,1568 @@
         "y": 0
       },
       "id": 4,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of leaked OpenStack servers.\nLeaked here means server instances that do not have a matching Machine resource.\n\n",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 1
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT\n        COUNT(s.id) AS total\nFROM openstack_orphan_server AS s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Number of Leaked Servers",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of servers using images that aren't listed in their respective cloud profile.\nOnly looks at non-leaked servers.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 4,
+            "y": 1
+          },
+          "id": 6,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(oumi.server_id) FROM openstack_unknown_machine_image as oumi\nJOIN openstack_project as p\nON oumi.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Servers with unknown images",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of leaked OpenStack servers.\nLeaked here means not mapped to a Machine resource.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 545
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 7,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT s.*\nFROM openstack_orphan_server AS s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Leaked Servers",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of OpenStack Server using images not specified in their respective Cloud Profile.\nOnly looks at non-leaked servers.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 19
+          },
+          "id": 8,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT oumi.*\nFROM openstack_unknown_machine_image as oumi\nJOIN openstack_project as p\nON oumi.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Servers with Unknown Images",
+          "type": "table"
+        }
+      ],
       "title": "Servers",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of leaked OpenStack servers.\nLeaked here means server instances that do not have a matching Machine resource.\n\n",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 0,
-        "y": 1
-      },
-      "id": 5,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT\n        COUNT(s.id) AS total\nFROM openstack_orphan_server AS s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Number of Leaked Servers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of servers using images that aren't listed in their respective cloud profile.\nOnly looks at non-leaked servers.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 4,
-        "y": 1
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(oumi.server_id) FROM openstack_unknown_machine_image as oumi\nJOIN openstack_project as p\nON oumi.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Servers with unknown images",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of leaked OpenStack servers.\nLeaked here means not mapped to a Machine resource.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 545
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 7,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT s.*\nFROM openstack_orphan_server AS s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Leaked Servers",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of OpenStack Server using images not specified in their respective Cloud Profile.\nOnly looks at non-leaked servers.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 8,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT oumi.*\nFROM openstack_unknown_machine_image as oumi\nJOIN openstack_project as p\nON oumi.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Servers with Unknown Images",
-      "type": "table"
-    },
-    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 1
       },
       "id": 3,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of leaked OpenStack Networks.\nDoes not include externally managed networks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 2
+          },
+          "id": 9,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT\n        COUNT(n.name) AS total\nFROM openstack_orphan_network AS n\nJOIN openstack_project as p\nON n.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Number of Leaked Networks",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of leaked OpenStack Subnets",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 4,
+            "y": 2
+          },
+          "id": 10,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(s.subnet_id) FROM openstack_orphan_subnet as s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Number of Leaked Subnets",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Leaked OpenStack Networks.\nDoes not include externally managed networks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 11,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT\n        n.*\nFROM openstack_orphan_network as n\nJOIN openstack_project as p\nON n.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Leaked Networks",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of leaked OpenStack subnets.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 12,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT s.* as project_name \nFROM openstack_orphan_subnet as s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Leaked Subnets",
+          "type": "table"
+        }
+      ],
       "title": "Networks & Subnets",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of leaked OpenStack Networks.\nDoes not include externally managed networks.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 0,
-        "y": 28
-      },
-      "id": 9,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT\n        COUNT(n.name) AS total\nFROM openstack_orphan_network AS n\nJOIN openstack_project as p\nON n.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Number of Leaked Networks",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of leaked OpenStack Subnets",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 4,
-        "y": 28
-      },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(s.subnet_id) FROM openstack_orphan_subnet as s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Number of Leaked Subnets",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Leaked OpenStack Networks.\nDoes not include externally managed networks.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 11,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT\n        n.*\nFROM openstack_orphan_network as n\nJOIN openstack_project as p\nON n.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Leaked Networks",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of leaked OpenStack subnets.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 46
-      },
-      "id": 12,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT s.* as project_name \nFROM openstack_orphan_subnet as s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Leaked Subnets",
-      "type": "table"
-    },
-    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 2
       },
       "id": 2,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of OpenStack Load Balancers which are linked to an orphaned network.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 3
+          },
+          "id": 13,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_loadbalancer as lb\nJOIN openstack_project as p\nON lb.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphaned Load Balancers",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of public (floating) IPs which are linked to leaked networks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 4,
+            "y": 3
+          },
+          "id": 14,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_floating_ip as ip\nJOIN openstack_project as p\nON ip.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Number of Leaked Public (Floating) IPs",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of OpenStack Pools which don't have mapped servers and are linked to an active shoot.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 8,
+            "y": 3
+          },
+          "id": 21,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_pool as pool\nJOIN openstack_project as p\nON pool.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphaned Pool",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "Number of OpenStack Pool Members which don't have a mapped server and are linked to an active shoot.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "fieldMinMax": false,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 12,
+            "y": 3
+          },
+          "id": 22,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_pool_member as pm\nJOIN openstack_project as p\nON pm.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphaned Pool Member",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of LBs which are linked to orphaned networks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "description"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 253
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 366
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "id": 15,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT \n  lb.*,\n  p.name as project_name\nFROM openstack_orphan_loadbalancer as lb\nJOIN openstack_project as p\nON lb.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphan Load Balancers",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of IPs which are linked with an orphan network.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "description"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 253
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 366
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 21
+          },
+          "id": 16,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT \n  ip.*,\n  p.name as project_name\nFROM openstack_orphan_floating_ip as ip\nJOIN openstack_project as p\nON ip.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphan floating (public) IPs",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of orphaned Pools",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "description"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 253
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 366
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 23,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT \n  pool.*,\n  p.name as project_name\nFROM openstack_orphan_pool as pool\nJOIN openstack_project as p\nON pool.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphan Pools",
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "ds_gardener_inventory"
+          },
+          "description": "List of Pools Members, missing attached servers.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": true,
+                "inspect": true
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "description"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 253
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "name"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 366
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 43
+          },
+          "id": 24,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": true,
+              "enablePagination": true,
+              "fields": "",
+              "reducer": [
+                "count"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "grafana-postgresql-datasource",
+                "uid": "ds_gardener_inventory"
+              },
+              "editorMode": "code",
+              "format": "table",
+              "rawQuery": true,
+              "rawSql": "SELECT \n  pm.*,\n  p.name as project_name\nFROM openstack_orphan_pool_member as pm\nJOIN openstack_project as p\nON pm.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Orphan Pools Members",
+          "type": "table"
+        }
+      ],
       "title": "LoadBalancers & Public IPs",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of OpenStack Load Balancers which are linked to an orphaned network.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 0,
-        "y": 58
-      },
-      "id": 13,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_loadbalancer as lb\nJOIN openstack_project as p\nON lb.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphaned Load Balancers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of public (floating) IPs which are linked to leaked networks.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 4,
-        "y": 58
-      },
-      "id": 14,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_floating_ip as ip\nJOIN openstack_project as p\nON ip.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Number of Leaked Public (Floating) IPs",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of OpenStack Pools which don't have mapped servers and are linked to an active shoot.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 8,
-        "y": 58
-      },
-      "id": 21,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_pool as pool\nJOIN openstack_project as p\nON pool.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphaned Pool",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "Number of OpenStack Pool Members which don't have a mapped server and are linked to an active shoot.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
-        "y": 58
-      },
-      "id": 22,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT COUNT(*)\nFROM openstack_orphan_pool_member as pm\nJOIN openstack_project as p\nON pm.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphaned Pool Member",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of LBs which are linked to orphaned networks.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "description"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 253
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 366
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 65
-      },
-      "id": 15,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT \n  lb.*,\n  p.name as project_name\nFROM openstack_orphan_loadbalancer as lb\nJOIN openstack_project as p\nON lb.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphan Load Balancers",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of IPs which are linked with an orphan network.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "description"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 253
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 366
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 76
-      },
-      "id": 16,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT \n  ip.*,\n  p.name as project_name\nFROM openstack_orphan_floating_ip as ip\nJOIN openstack_project as p\nON ip.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphan floating (public) IPs",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of orphaned Pools",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "description"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 253
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 366
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 87
-      },
-      "id": 23,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT \n  pool.*,\n  p.name as project_name\nFROM openstack_orphan_pool as pool\nJOIN openstack_project as p\nON pool.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphan Pools",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "ds_gardener_inventory"
-      },
-      "description": "List of Pools Members, missing attached servers.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "description"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 253
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 366
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 98
-      },
-      "id": 24,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "ds_gardener_inventory"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "rawQuery": true,
-          "rawSql": "SELECT \n  pm.*,\n  p.name as project_name\nFROM openstack_orphan_pool_member as pm\nJOIN openstack_project as p\nON pm.project_id = p.project_id\nWHERE p.name in ($openstack_project);",
-          "refId": "A",
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          }
-        }
-      ],
-      "title": "Orphan Pools Members",
-      "type": "table"
-    },
-    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 3
       },
       "id": 17,
       "panels": [
@@ -1625,7 +1628,7 @@
             "h": 7,
             "w": 4,
             "x": 0,
-            "y": 33
+            "y": 4
           },
           "id": 19,
           "options": {
@@ -1683,7 +1686,7 @@
             "type": "grafana-postgresql-datasource",
             "uid": "ds_gardener_inventory"
           },
-          "description": "List of leaked OpenStack servers.\nLeaked here means not mapped to a Machine resource.",
+          "description": "List of leaked OpenStack containers.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1767,7 +1770,7 @@
             "h": 7,
             "w": 20,
             "x": 4,
-            "y": 33
+            "y": 4
           },
           "id": 20,
           "options": {
@@ -1794,7 +1797,7 @@
               "editorMode": "code",
               "format": "table",
               "rawQuery": true,
-              "rawSql": "SELECT s.*\nFROM openstack_orphan_server AS s\nJOIN openstack_project as p\nON s.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
+              "rawSql": "SELECT c.*\nFROM openstack_orphan_container AS c\nJOIN openstack_project as p\nON c.project_id = p.project_id\nWHERE p.name in ($openstack_project);\n",
               "refId": "A",
               "sql": {
                 "columns": [
@@ -1815,7 +1818,7 @@
               }
             }
           ],
-          "title": "Leaked Servers",
+          "title": "Leaked Containers",
           "type": "table"
         }
       ],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,18 @@ services:
       timeout: 5s
       retries: 5
 
+  vault:
+    image: hashicorp/vault:1.20
+    ports:
+      - 8200:8200
+    healthcheck:
+      test: curl --fail -I http://localhost:8200/ui/sys/health || exit 1
+      interval: 15s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./dev/local/vault:/vault/file
+
   worker:
     build:
       context: .

--- a/docs/auth-openstack.md
+++ b/docs/auth-openstack.md
@@ -182,7 +182,7 @@ secret.
 The following example creates a `v3password` secret in Vault for username and
 password authentication.
 
-``` yaml
+``` shell
 vault kv put kvv2/path/to/my/secret \
       kind=v3password \
       username=my-username \
@@ -192,7 +192,7 @@ vault kv put kvv2/path/to/my/secret \
 This example creates a `v3applicationcredential` secret in Vault for Application
 Credentials authentication.
 
-``` yaml
+``` shell
 vault kv put kvv2/path/to/my/secret \
       kind=v3applicationcredential \
       application_credential_id=app-id \

--- a/docs/auth-openstack.md
+++ b/docs/auth-openstack.md
@@ -176,7 +176,7 @@ openstack:
 When using `vault_secret` for configuring OpenStack credentials the Vault secret
 may provide a `v3password` (username and password pair) or
 `v3applicationcredential` ([Application
-Credentials](https://docs.openstack.org/keystone/queens/user/application_credentials.html))
+Credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html))
 secret.
 
 The following example creates a `v3password` secret in Vault for username and

--- a/docs/auth-openstack.md
+++ b/docs/auth-openstack.md
@@ -1,56 +1,200 @@
-# Authn/Authz
-Users of the Inventory can provide OpenStack service specific credentials,
-which are then used against the specified OpenStack Keystone service.
-Multiple credentials can be provided per service, with the unique property
-being project_id, which is expected to be unique globally. With this setup,
-users can collect resources from multiple regions/clusters, as long as the
-credentials are configured properly.
+# OpenStack
 
-Make sure the credentials you provide have the roles needed to access the 
-respective resources. If there are resources with different policies in the 
-same service type that need to be collected, you can list different credentials
-for both. This might cause an error in inventory logs, but won't stop
-the collection process.
+Users of the Inventory can provide OpenStack service specific credentials, which
+are then used against the specified OpenStack Keystone service.  Multiple
+credentials can be provided per service, with the unique property being
+project_id, which is expected to be unique globally. With this setup, users can
+collect resources from multiple regions/clusters, as long as the credentials are
+configured properly.
+
+Make sure the credentials you provide have the roles needed to access the
+respective resources. If there are resources with different policies in the same
+service type that need to be collected, you can list different credentials for
+both. This might cause an error in inventory logs, but won't stop the collection
+process.
 
 A full example can be found at `./examples/config.yaml`
 
-Example credentials section:
-```
-credentials:
-  local:
-    authentication: password
-    password:
-      username: <your username>
-      password_file: <path-to-file-with-password>
-  named_credentials_myproject:
-    authentication: app_credentials
-    app_credentials:
-      app_credentials_id: <id>
-      app_credentials_name: <credentials_name>
-      app_credentials_secret_file: <secret>
-```
+Example configuration for OpenStack collection.
 
-The two supported credential types are `password` and `app_credentials`.
+``` yaml
+# OpenStack specific configuration
+openstack:
+  is_enabled: true
 
-The service section must also be configured.
-Example services section populated for the network service:
-
-```
-services:
-  network:
-    - use_credentials: named_credentials_myproject #defined above
+  # The `credentials' section provides named credentials, which are used by the
+  # various OpenStack services. The currently supported authentication
+  # mechanisms are `password' for username and password, `app_credentials' for
+  # Application Credentials and `vault_secret' for credentials provided by a
+  # Vault secret..
+  credentials:
+    # Example of using username/password for authentication
+    foo:
       domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
       region: <region>
-      project: <project name>
-      project_id: <project id of the project above>
-      auth_endpoint: https://<keystone-url>
+      authentication: password
+      password:
+        username: "<username>"
+        password_file: "<path-to-password-file>"
+    # Example of using Application Credentials for authentication
+    bar:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
+      authentication: app_credentials
+      app_credentials:
+        app_credentials_id: "<app-id>"
+        app_credentials_secret_file: "<path-to-secret-file>"
+
+  # OpenStack services configuration
+  services:
+    # Used for collecting OpenStack Servers
+    compute:
+      use_credentials:
+        - foo
+        - bar
+    # Used for collecting OpenStack Networks and Subnets
+    network:
+      use_credentials:
+        - foo
+    # Used for collecting OpenStack Containers and Objects
+    object_storage:
+      use_credentials:
+        - bar
+    # Used for collecting OpenStack LoadBalancers
+    load_balancer:
+      use_credentials:
+        - foo
+        - bar
+    # Used for collecting OpenStack Project metadata
+    identity:
+      use_credentials:
+        - foo
+        - bar
 ```
 
-Something to note here is, that if you don't supply any of the fields,
-validation will fail and the inventory will not start. Currently, we do not 
-explicitly differentiate between the different scopes of auth tokens.
-All resource requests are made with project scope.
+The supported authentication methods when configuring named credentials are
+`password`, `app_credentials` and `vault_secret`.
 
-The project_id field is redundant, since project name, domain and region combined
-with credential name uniquely identify a service client instantiation.
-It will be removed in a future PR.
+The `services` section is used for configuring collection from the respective
+OpenStack service. Each service may specify one or more named credentials, which
+will be used during collection.
+
+In order to configure OpenStack credentials from a Vault secret we first need to
+configure a Vault server in the Inventory config. Example Vault configuration
+with a single Vault server is provided below.
+
+``` yaml
+# Vault settings.
+vault:
+  is_enabled: true
+
+  # The Vault servers for which API clients will be created.
+  servers:
+    # Dev Vault server example
+    vault-dev:
+      # Endpoint of the Vault server
+      endpoint: http://localhost:8200/
+
+      # Optional TLS settings
+      # tls:
+      #   ca_cert: /path/to/ca.crt
+      #   ca_cert_bytes: "PEM-encoded CA bundle"
+      #   ca_path: /path/to/ca/cert/files
+      #   client_cert: /path/to/client.crt
+      #   client_key: /path/to/client.key
+      #   tls_server_name: SNI-host
+      #   insecure: false
+
+      # The supported Auth Methods are `token' and `jwt'.
+      auth_method: token
+
+      # Auth settings when using `token' auth method.
+      token_auth:
+        token_path: /path/to/my/token
+```
+
+Please refer to the [examples/config.yaml](../examples/config.yaml) file for
+additional details and examples on how to configure Vault servers with different
+Authentication Methods (e.g. [JWT Auth
+Method](https://developer.hashicorp.com/vault/docs/auth/jwt)) as well.
+
+Once we configure Vault servers we can then configure OpenStack named
+credentials, which use Vault secrets. The following example shows a single named
+credential configured from a Vault secret.
+
+``` yaml
+# OpenStack specific configuration
+openstack:
+  is_enabled: true
+
+  credentials:
+    # Example of using Vault secret for OpenStack credentials
+    foo:
+      domain: my-domain
+      auth_endpoint: https://example.org/v3
+      project: my-project-name
+      region: region-1
+      authentication: vault_secret
+      vault_secret:
+        # Must refer to a Vault server defined in `vault.servers'
+        server: vault-dev
+
+        # Mount point of a KV v2 secret engine
+        secret_engine: kvv2
+
+        # Path to the secret
+        secret_path: path/to/my/secret
+
+  # OpenStack services configuration
+  services:
+    # Used for collecting OpenStack Servers
+    compute:
+      use_credentials:
+        - foo
+    # Used for collecting OpenStack Networks and Subnets
+    network:
+      use_credentials:
+        - foo
+    # Used for collecting OpenStack Containers and Objects
+    object_storage:
+      use_credentials:
+        - foo
+    # Used for collecting OpenStack LoadBalancers
+    load_balancer:
+      use_credentials:
+        - foo
+    # Used for collecting OpenStack Project metadata
+    identity:
+      use_credentials:
+        - foo
+```
+
+When using `vault_secret` for configuring OpenStack credentials the Vault secret
+may provide a `v3password` (username and password pair) or
+`v3applicationcredential` ([Application
+Credentials](https://docs.openstack.org/keystone/queens/user/application_credentials.html))
+secret.
+
+The following example creates a `v3password` secret in Vault for username and
+password authentication.
+
+``` yaml
+vault kv put kvv2/path/to/my/secret \
+      kind=v3password \
+      username=my-username \
+      password=my-p4ssw0rd
+```
+
+This example creates a `v3applicationcredential` secret in Vault for Application
+Credentials authentication.
+
+``` yaml
+vault kv put kvv2/path/to/my/secret \
+      kind=v3applicationcredential \
+      application_credential_id=app-id \
+      application_credential_secret=app-s3cr37
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -434,6 +434,7 @@ The services which will be started are summarized in the table below.
 | `grafana`    | Grafana instance                          |
 | `prometheus` | Prometheus instance                       |
 | `pgadmin`    | PostgreSQL Admin Interface                |
+| `vault`      | Vault server in development mode          |
 
 Once the services are up and running, you can access the following endpoints from
 your local system.
@@ -448,6 +449,7 @@ your local system.
 | http://localhost:9090/        | Prometheus UI                  |
 | http://localhost:7080/        | pgAdmin UI                     |
 | http://localhost:6080/metrics | Metrics endpoint for Worker    |
+| http://localhost:8200/        | Development Vault server       |
 
 ### minikube
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -42,7 +42,7 @@ vault:
   # The Vault servers for which API clients will be created.
   servers:
     # Dev Vault server example
-    dev:
+    vault-dev:
       # Endpoint of the Vault server
       endpoint: http://localhost:8200/
 
@@ -64,7 +64,7 @@ vault:
         token_path: /path/to/my/token
 
     # # Production Vault server example
-    # prod:
+    # vault-prod:
     #   # Endpoint of the Vault server
     #   endpoint: https://vault.example.org:8200/
 
@@ -353,9 +353,12 @@ openstack:
   is_enabled: false
 
   # The `credentials' section provides named credentials, which are used by the
-  # various OpenStack services. The currently supported authentication mechanisms are `password' for username and password
-  # and `app_credentials' for application credentials.
+  # various OpenStack services. The currently supported authentication
+  # mechanisms are `password' for username and password, `app_credentials' for
+  # Application Credentials and `vault_secret' for credentials provided by a
+  # Vault secret..
   credentials:
+    # Example of using username/password for authentication
     local:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -365,6 +368,7 @@ openstack:
       password:
         username: "<username>"
         password_file: "<path-to-password-file>"
+    # Example of using Application Credentials for authentication
     sa1:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -383,6 +387,23 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    sa3:
+      domain: <domain>
+      auth_endpoint: <endpoint>
+      project: <project_name>
+      region: <region>
+      authentication: vault_secret
+      vault_secret:
+        # Must refer to a server already defined in `vault.servers'
+        server: vault-dev
+
+        # Mount point of a KV v2 secret engine
+        secret_engine: kvv2
+
+        # Path to the secret
+        secret_path: my/secret
+
+  # OpenStack services configuration
   services:
     # Used for collecting OpenStack Servers
     compute:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -378,6 +378,7 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    # Another Application Credentials example
     sa2:
       domain: <domain>
       auth_endpoint: <endpoint>
@@ -387,6 +388,7 @@ openstack:
       app_credentials:
         app_credentials_id: "<app-id>"
         app_credentials_secret_file: "<path-to-secret-file>"
+    # Example of using a Vault secret
     sa3:
       domain: <domain>
       auth_endpoint: <endpoint>

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -71,6 +71,11 @@ const (
 	// authentication mechanism for OpenStack, which uses application credentials.
 	OpenStackAuthenticationMethodAppCredentials = "app_credentials"
 
+	// OpenStackAuthenticationMethodVaultSecret is the name of the
+	// authentication mechanism for OpenStack, which reads credentials from
+	// a Vault secret.
+	OpenStackAuthenticationMethodVaultSecret = "vault_secret"
+
 	// DefaultWorkerMetricsAddress is the network address from which the
 	// worker is serving metrics.
 	DefaultWorkerMetricsAddress = ":6080"

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -265,9 +265,10 @@ type OpenStackServiceCredentials struct {
 // API clients.
 type OpenStackCredentialsConfig struct {
 	// Authentication specifies the authentication method/strategy to use
-	// when creating OpenStack API clients.
-	// The currently supported authentication mechanisms are `password' for username/password
-	// and `app_credentials'.
+	// when creating OpenStack API clients. The currently supported
+	// authentication mechanisms are `password' for username/password,
+	// `app_credentials' for Application Credentials and `vault_secret' for
+	// reading credentials from a Vault secret.
 	Authentication string `yaml:"authentication"`
 
 	// Password provides the settings to use for authentication when using username/password.
@@ -275,6 +276,10 @@ type OpenStackCredentialsConfig struct {
 
 	// AppCredentials provides the settings to use for authentication when using application credentials.
 	AppCredentials OpenStackAppCredentialsConfig `yaml:"app_credentials"`
+
+	// VaultSecret specifies config settings for reading OpenStack
+	// credentials from a Vault secret.
+	VaultSecret OpenStackVaultSecretConfig `yaml:"vault_secret"`
 
 	// Domain specifies the domain to use when initializing an OpenStack client.
 	Domain string `yaml:"domain"`
@@ -287,6 +292,21 @@ type OpenStackCredentialsConfig struct {
 
 	// AuthEndpoint specifies the authentication endpoint to use when initializing an OpenStack client.
 	AuthEndpoint string `yaml:"auth_endpoint"`
+}
+
+// OpenStackVaultSecretConfig provides the config settings for reading OpenStack
+// credentials from a Vault secret.
+type OpenStackVaultSecretConfig struct {
+	// Server specifies the name of the Vault server, which contains the
+	// secret.
+	Server string `yaml:"server"`
+
+	// SecretEngine is the mount path for a KV v2 secret engine, which
+	// provides the secret.
+	SecretEngine string `yaml:"secret_engine"`
+
+	// SecretPath specifies the path to the secret.
+	SecretPath string `yaml:"secret_path"`
 }
 
 // OpenStackPasswordConfig provides the settings to use for authentication when using username/password.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for creating OpenStack API clients from Vault secrets.

- Add Vault to the local development setup
- Updated documentation and examples how to create Vault secrets for OpenStack
- Update deployment configs and manifests

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
feat: add support for creating openstack clients from vault secrets
```
