### PR TITLE
Filter OpenStack projects by name

### DIFF
--- a/pkg/openstack/tasks/projects.go
+++ b/pkg/openstack/tasks/projects.go
@@ -176,18 +176,20 @@ func collectProjects(ctx context.Context, payload CollectProjectsPayload) error 
 				}
 
 				for _, p := range projectList {
-					item := models.Project{
-						ProjectID:   p.ID,
-						Name:        p.Name,
-						Domain:      client.Domain,
-						Region:      client.Region,
-						ParentID:    p.ParentID,
-						Description: p.Description,
-						Enabled:     p.Enabled,
-						IsDomain:    p.IsDomain,
-					}
+					if p.Name == payload.Scope.Project {
+						item := models.Project{
+							ProjectID:   p.ID,
+							Name:        p.Name,
+							Domain:      client.Domain,
+							Region:      client.Region,
+							ParentID:    p.ParentID,
+							Description: p.Description,
+							Enabled:     p.Enabled,
+							IsDomain:    p.IsDomain,
+						}
 
-					items = append(items, item)
+						items = append(items, item)
+					}
 				}
 
 				return true, nil


### PR DESCRIPTION
When collecting projects, only collect the one currently used as client context.
This helps not collect a single project through multiple clients and not collect projects we have access to but do not target.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Filter collected OpenStack projects
```
