### PR TITLE
Introduce project IDs to OpenStack client initialization

### DIFF
--- a/pkg/clients/openstack/client.go
+++ b/pkg/clients/openstack/client.go
@@ -14,6 +14,9 @@ type ClientScope struct {
 	// Project is the project associated with the client.
 	Project string
 
+	// ProjectID is the project ID associated with the client.
+	ProjectID string
+
 	// Domain is the domain associated with the client.
 	Domain string
 

--- a/pkg/openstack/tasks/floating_ips.go
+++ b/pkg/openstack/tasks/floating_ips.go
@@ -162,7 +162,10 @@ func collectFloatingIPs(ctx context.Context, payload CollectFloatingIPsPayload) 
 
 	items := make([]models.FloatingIP, 0)
 
-	err := floatingips.List(client.Client, nil).
+	opts := floatingips.ListOpts{
+		ProjectID: client.ProjectID,
+	}
+	err := floatingips.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				floatingIPList, err := floatingips.ExtractFloatingIPs(page)

--- a/pkg/openstack/tasks/loadbalancers.go
+++ b/pkg/openstack/tasks/loadbalancers.go
@@ -161,7 +161,10 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 	items := make([]models.LoadBalancer, 0)
 	lbWithPoolItems := make([]models.LoadBalancerWithPool, 0)
 
-	err := loadbalancers.List(client.Client, nil).
+	opts := loadbalancers.ListOpts{
+		ProjectID: client.ProjectID,
+	}
+	err := loadbalancers.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				lbList, err := loadbalancers.ExtractLoadBalancers(page)
@@ -290,7 +293,7 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 		return err
 	}
 
-	count, err = out.RowsAffected()
+	poolCount, err := out.RowsAffected()
 	if err != nil {
 		return err
 	}
@@ -300,7 +303,7 @@ func collectLoadBalancers(ctx context.Context, payload CollectLoadBalancersPaylo
 		"project", payload.Scope.Project,
 		"domain", payload.Scope.Domain,
 		"region", payload.Scope.Region,
-		"count", count,
+		"count", poolCount,
 	)
 
 	return nil

--- a/pkg/openstack/tasks/networks.go
+++ b/pkg/openstack/tasks/networks.go
@@ -151,7 +151,7 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 			payload.Scope.Region,
 		)
 		key := metrics.Key(
-			TaskCollectServers,
+			TaskCollectNetworks,
 			payload.Scope.Project,
 			payload.Scope.Domain,
 			payload.Scope.Region,
@@ -161,7 +161,10 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 
 	items := make([]models.Network, 0)
 
-	err := networks.List(client.Client, nil).
+	opts := networks.ListOpts {
+		ProjectID: client.ClientScope.ProjectID,
+	}
+	err := networks.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				networkList, err := networks.ExtractNetworks(page)

--- a/pkg/openstack/tasks/networks.go
+++ b/pkg/openstack/tasks/networks.go
@@ -162,7 +162,7 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 	items := make([]models.Network, 0)
 
 	opts := networks.ListOpts {
-		ProjectID: client.ClientScope.ProjectID,
+		ProjectID: client.ProjectID,
 	}
 	err := networks.List(client.Client, opts).
 		EachPage(ctx,

--- a/pkg/openstack/tasks/networks.go
+++ b/pkg/openstack/tasks/networks.go
@@ -161,7 +161,7 @@ func collectNetworks(ctx context.Context, payload CollectNetworksPayload) error 
 
 	items := make([]models.Network, 0)
 
-	opts := networks.ListOpts {
+	opts := networks.ListOpts{
 		ProjectID: client.ProjectID,
 	}
 	err := networks.List(client.Client, opts).

--- a/pkg/openstack/tasks/objects.go
+++ b/pkg/openstack/tasks/objects.go
@@ -211,7 +211,7 @@ func collectObjects(ctx context.Context, payload CollectObjectsPayload) error {
 						item := models.Object{
 							Name:          o.Name,
 							ContainerName: name,
-							ProjectID:     client.Project,
+							ProjectID:     client.ProjectID,
 							ContentType:   o.ContentType,
 							LastModified:  o.LastModified,
 							IsLatest:      o.IsLatest,

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -163,7 +163,7 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 	memberItems := make([]models.PoolMember, 0)
 
 	opts := pools.ListOpts{
-		ProjectID: client.ClientScope.ProjectID,
+		ProjectID: client.ProjectID,
 	}
 	err := pools.List(client.Client, opts).
 		EachPage(ctx,

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -162,7 +162,10 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 	poolItems := make([]models.Pool, 0)
 	memberItems := make([]models.PoolMember, 0)
 
-	err := pools.List(client.Client, nil).
+	opts := pools.ListOpts{
+		ProjectID: client.ClientScope.ProjectID,
+	}
+	err := pools.List(client.Client, opts).
 		EachPage(ctx,
 			func(ctx context.Context, page pagination.Page) (bool, error) {
 				extractedPools, err := pools.ExtractPools(page)
@@ -180,7 +183,10 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 				}
 
 				for _, pool := range extractedPools {
-					err = pools.ListMembers(client.Client, pool.ID, nil).
+					memberOpts := pools.ListMembersOpts{
+						ProjectID: client.ProjectID,
+					}
+					err = pools.ListMembers(client.Client, pool.ID, memberOpts).
 						EachPage(ctx,
 							func(ctx context.Context, page pagination.Page) (bool, error) {
 								extractedMembers, err := pools.ExtractMembers(page)

--- a/pkg/openstack/tasks/ports.go
+++ b/pkg/openstack/tasks/ports.go
@@ -163,7 +163,7 @@ func collectPorts(ctx context.Context, payload CollectPortsPayload) error {
 	portIPs := make([]models.PortIP, 0)
 
 	opts := ports.ListOpts{
-		ProjectID: client.ClientScope.ProjectID,
+		ProjectID: client.ProjectID,
 	}
 	err := ports.List(client.Client, opts).
 		EachPage(ctx,

--- a/pkg/openstack/tasks/ports.go
+++ b/pkg/openstack/tasks/ports.go
@@ -162,7 +162,10 @@ func collectPorts(ctx context.Context, payload CollectPortsPayload) error {
 	items := make([]models.Port, 0)
 	portIPs := make([]models.PortIP, 0)
 
-	err := ports.List(client.Client, ports.ListOpts{}).
+	opts := ports.ListOpts{
+		ProjectID: client.ClientScope.ProjectID,
+	}
+	err := ports.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				portList, err := ports.ExtractPorts(page)

--- a/pkg/openstack/tasks/routers.go
+++ b/pkg/openstack/tasks/routers.go
@@ -156,7 +156,10 @@ func collectRouters(ctx context.Context, payload CollectRoutersPayload) error {
 	items := make([]models.Router, 0)
 	externalIPs := make([]models.RouterExternalIP, 0)
 
-	err := routers.List(client.Client, routers.ListOpts{}).
+	opts := routers.ListOpts{
+		ProjectID: client.ProjectID,
+	}
+	err := routers.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				routerList, err := routers.ExtractRouters(page)

--- a/pkg/openstack/tasks/servers.go
+++ b/pkg/openstack/tasks/servers.go
@@ -161,7 +161,10 @@ func collectServers(ctx context.Context, payload CollectServersPayload) error {
 
 	items := make([]models.Server, 0)
 
-	err := servers.List(client.Client, nil).
+	opts := servers.ListOpts{
+		TenantID: client.ProjectID,
+	}
+	err := servers.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				serverList, err := servers.ExtractServers(page)

--- a/pkg/openstack/tasks/subnets.go
+++ b/pkg/openstack/tasks/subnets.go
@@ -161,7 +161,10 @@ func collectSubnets(ctx context.Context, payload CollectSubnetsPayload) error {
 
 	items := make([]models.Subnet, 0)
 
-	err := subnets.List(client.Client, nil).
+	opts := subnets.ListOpts {
+		ProjectID: client.ClientScope.ProjectID,
+	}
+	err := subnets.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				subnetList, err := subnets.ExtractSubnets(page)

--- a/pkg/openstack/tasks/subnets.go
+++ b/pkg/openstack/tasks/subnets.go
@@ -161,8 +161,8 @@ func collectSubnets(ctx context.Context, payload CollectSubnetsPayload) error {
 
 	items := make([]models.Subnet, 0)
 
-	opts := subnets.ListOpts {
-		ProjectID: client.ClientScope.ProjectID,
+	opts := subnets.ListOpts{
+		ProjectID: client.ProjectID,
 	}
 	err := subnets.List(client.Client, opts).
 		EachPage(ctx,

--- a/pkg/openstack/tasks/volumes.go
+++ b/pkg/openstack/tasks/volumes.go
@@ -161,7 +161,10 @@ func collectVolumes(ctx context.Context, payload CollectVolumesPayload) error {
 
 	items := make([]models.Volume, 0)
 
-	err := volumes.List(client.Client, nil).
+	opts := volumes.ListOpts{
+		TenantID: client.ProjectID,
+	}
+	err := volumes.List(client.Client, opts).
 		EachPage(ctx,
 			func(_ context.Context, page pagination.Page) (bool, error) {
 				volumeList, err := volumes.ExtractVolumes(page)

--- a/pkg/openstack/utils/utils.go
+++ b/pkg/openstack/utils/utils.go
@@ -47,6 +47,10 @@ func IsValidProjectScope(scope openstackclients.ClientScope) error {
 		return errors.New("missing project name")
 	}
 
+	if scope.ProjectID == "" {
+		return errors.New("missing project ID")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, OpenStack clients retrieve the project IDs of their respective user/app credential during client creation.
This is done by creating a separate identity client, used for listing all available projects and filtering out the one with a name equal to the name configured in the client credentials. Since we also specify domain name there, we can count on there only being one project with such a name, as they should be unique per domain.
This project ID is then used to filter out most resource ListAvailable requests to be scoped to the current project (not all available ones, which might be in another project our client has access to). This excludes containers and objects, since they aren't project scoped. Extra logic might be introduced there.

Also fixed some minor issues:
- OpenStack LB collection metric (inventory_openstack_loadbalancers) wasn't correctly populated.
- OpenStack networks used the metric name of OpenStack servers, causing incorrect data for the second and missing for the first

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Introduce Project ID to OpenStack client initialization.
```
