### PR TITLE
Add view for openstack orphan volumes

### DIFF
--- a/internal/pkg/migrations/20250813084509_add_openstack_orphan_volume.tx.down.sql
+++ b/internal/pkg/migrations/20250813084509_add_openstack_orphan_volume.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "openstack_orphan_volume";

--- a/internal/pkg/migrations/20250813084509_add_openstack_orphan_volume.tx.up.sql
+++ b/internal/pkg/migrations/20250813084509_add_openstack_orphan_volume.tx.up.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE VIEW "openstack_orphan_volume" AS
+SELECT 
+    v.volume_id,
+    v.name,
+    v.project_id,
+    v.domain,
+    v.region,
+    v.user_id,
+    v.availability_zone,
+    v.size,
+    v.volume_type,
+    v.status,
+    v.replication_status,
+    v.bootable,
+    v.encrypted,
+    v.multi_attach,
+    v.snapshot_id,
+    v.description,
+    v.volume_created_at,
+    v.volume_updated_at
+FROM openstack_volume as v
+WHERE v.availability_zone = '';


### PR DESCRIPTION
The rule for orphan volumes is currently "no availability zone set". This goes back to the initial request for tracking orphan volumes, where the sapcc lime api (request/quota tracking) noticed volumes without AZs. Currently, the view will only try to catch that. If more rules arise, they can be added incrementally.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
add view openstack_orphan_volume
```
