### PR TITLE
AWS DHCP option sets

### DIFF
--- a/internal/pkg/migrations/20250911120919_aws_vpc_add_dhcp_option_set_id.tx.down.sql
+++ b/internal/pkg/migrations/20250911120919_aws_vpc_add_dhcp_option_set_id.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "aws_vpc" DROP COLUMN "dhcp_option_set_id";

--- a/internal/pkg/migrations/20250911120919_aws_vpc_add_dhcp_option_set_id.tx.up.sql
+++ b/internal/pkg/migrations/20250911120919_aws_vpc_add_dhcp_option_set_id.tx.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "aws_vpc" ADD COLUMN "dhcp_option_set_id" VARCHAR NOT NULL DEFAULT '';

--- a/internal/pkg/migrations/20250911123517_aws_dhcp_option_set.tx.down.sql
+++ b/internal/pkg/migrations/20250911123517_aws_dhcp_option_set.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "aws_dhcp_option_set";

--- a/internal/pkg/migrations/20250911123517_aws_dhcp_option_set.tx.up.sql
+++ b/internal/pkg/migrations/20250911123517_aws_dhcp_option_set.tx.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "aws_dhcp_option_set" (
+    "name" varchar NOT NULL,
+    "set_id" varchar NOT NULL,
+    "account_id" varchar NOT NULL,
+    "region_name" varchar NOT NULL,
+
+    "id" UUID DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("id"),
+    CONSTRAINT "aws_dhcp_option_set_key" UNIQUE ("set_id", "account_id")
+);

--- a/internal/pkg/migrations/20250911130115_aws_orphan_dhcp_option_set.tx.down.sql
+++ b/internal/pkg/migrations/20250911130115_aws_orphan_dhcp_option_set.tx.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "aws_orphan_dhcp_option_set";

--- a/internal/pkg/migrations/20250911130115_aws_orphan_dhcp_option_set.tx.up.sql
+++ b/internal/pkg/migrations/20250911130115_aws_orphan_dhcp_option_set.tx.up.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW "aws_orphan_dhcp_option_set" AS
+SELECT
+    d.set_id,
+    d.name,
+    d.account_id,
+    d.region_name
+FROM aws_dhcp_option_set as d
+LEFT JOIN aws_vpc as v ON d.set_id = v.dhcp_option_set_id
+WHERE  v.vpc_id IS NULL;

--- a/pkg/aws/models/models.go
+++ b/pkg/aws/models/models.go
@@ -26,6 +26,7 @@ const (
 	LoadBalancerModelName                   = "aws:model:loadbalancer"
 	BucketModelName                         = "aws:model:bucket"
 	NetworkInterfaceModelName               = "aws:model:network_interface"
+	DHCPOptionSetModelName                  = "aws:model:dhcp_option_set"
 	RegionToAZModelName                     = "aws:model:link_region_to_az"
 	RegionToVPCModelName                    = "aws:model:link_region_to_vpc"
 	VPCToSubnetModelName                    = "aws:model:link_vpc_to_subnet"
@@ -53,6 +54,7 @@ var models = map[string]any{
 	LoadBalancerModelName:     &LoadBalancer{},
 	BucketModelName:           &Bucket{},
 	NetworkInterfaceModelName: &NetworkInterface{},
+	DHCPOptionSetModelName:    &DHCPOptionSet{},
 
 	// Link models
 	RegionToAZModelName:                     &RegionToAZ{},
@@ -184,16 +186,17 @@ type VPC struct {
 	bun.BaseModel `bun:"table:aws_vpc"`
 	coremodels.Model
 
-	Name       string  `bun:"name,notnull"`
-	VpcID      string  `bun:"vpc_id,notnull,unique:aws_vpc_key"`
-	AccountID  string  `bun:"account_id,notnull,unique:aws_vpc_key"`
-	State      string  `bun:"state,notnull"`
-	IPv4CIDR   string  `bun:"ipv4_cidr,notnull"`
-	IPv6CIDR   string  `bun:"ipv6_cidr,nullzero"`
-	IsDefault  bool    `bun:"is_default,notnull"`
-	OwnerID    string  `bun:"owner_id,notnull"`
-	RegionName string  `bun:"region_name,notnull"`
-	Region     *Region `bun:"rel:has-one,join:region_name=name,join:account_id=account_id"`
+	Name            string  `bun:"name,notnull"`
+	VpcID           string  `bun:"vpc_id,notnull,unique:aws_vpc_key"`
+	AccountID       string  `bun:"account_id,notnull,unique:aws_vpc_key"`
+	State           string  `bun:"state,notnull"`
+	IPv4CIDR        string  `bun:"ipv4_cidr,notnull"`
+	IPv6CIDR        string  `bun:"ipv6_cidr,nullzero"`
+	IsDefault       bool    `bun:"is_default,notnull"`
+	OwnerID         string  `bun:"owner_id,notnull"`
+	DHCPOptionSetID string  `bun:"dhcp_option_set_id,notnull"`
+	RegionName      string  `bun:"region_name,notnull"`
+	Region          *Region `bun:"rel:has-one,join:region_name=name,join:account_id=account_id"`
 }
 
 // Subnet represents an AWS Subnet
@@ -376,6 +379,18 @@ type LoadBalancerToNetworkInterface struct {
 
 	LoadBalancerID     uuid.UUID `bun:"lb_id,notnull,type:uuid,unique:l_aws_lb_to_net_interface_key"`
 	NetworkInterfaceID uuid.UUID `bun:"ni_id,notnull,type:uuid,unique:l_aws_lb_to_net_interface_key"`
+}
+
+// DHCPOptionSet represents an AWS DHCP option set
+type DHCPOptionSet struct {
+	bun.BaseModel `bun:"table:aws_dhcp_option_set"`
+	coremodels.Model
+
+	Name       string  `bun:"name,notnull"`
+	AccountID  string  `bun:"account_id,notnull,unique:aws_dhcp_option_set_key"`
+	SetID      string  `bun:"set_id,notnull,unique:aws_dhcp_option_set_key"`
+	RegionName string  `bun:"region_name,notnull"`
+	Region     *Region `bun:"rel:has-one,join:region_name=name,join:account_id=account_id"`
 }
 
 // init registers the models with the [registry.ModelRegistry]

--- a/pkg/aws/tasks/dhcpoptionsets.go
+++ b/pkg/aws/tasks/dhcpoptionsets.go
@@ -210,10 +210,10 @@ func collectDHCPOptionSets(ctx context.Context, payload CollectDHCPOptionSetsPay
 		}
 
 		item := models.DHCPOptionSet{
-			Name:         name,
-			AccountID:    payload.AccountID,
-			SetID:        *set.DhcpOptionsId,
-			RegionName:   payload.Region,
+			Name:       name,
+			AccountID:  payload.AccountID,
+			SetID:      *set.DhcpOptionsId,
+			RegionName: payload.Region,
 		}
 		dhcpOptionSets = append(dhcpOptionSets, item)
 	}

--- a/pkg/aws/tasks/dhcpoptionsets.go
+++ b/pkg/aws/tasks/dhcpoptionsets.go
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/hibiken/asynq"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gardener/inventory/pkg/aws/constants"
+	"github.com/gardener/inventory/pkg/aws/models"
+	awsutils "github.com/gardener/inventory/pkg/aws/utils"
+	asynqclient "github.com/gardener/inventory/pkg/clients/asynq"
+	awsclients "github.com/gardener/inventory/pkg/clients/aws"
+	"github.com/gardener/inventory/pkg/clients/db"
+	"github.com/gardener/inventory/pkg/metrics"
+	asynqutils "github.com/gardener/inventory/pkg/utils/asynq"
+)
+
+const (
+	// TaskCollectDHCPOptionSets is the name of the task for collecting AWS DHCP option sets.
+	TaskCollectDHCPOptionSets = "aws:task:collect-dhcp-option-sets"
+)
+
+// CollectDHCPOptionSetsPayload is the payload, which is used for collecting AWS DHCP option sets.
+type CollectDHCPOptionSetsPayload struct {
+	// Region specifies the region from which to collect.
+	Region string `json:"region" yaml:"region"`
+
+	// AccountID specifies the AWS Account ID, which is associated with a
+	// registered client.
+	AccountID string `json:"account_id" yaml:"account_id"`
+}
+
+// NewCollectDHCPOptionSetsTask creates a new [asynq.Task] for collecting AWS DHCP option sets without
+// specifying a payload.
+func NewCollectDHCPOptionSetsTask() *asynq.Task {
+	return asynq.NewTask(TaskCollectDHCPOptionSets, nil)
+}
+
+// HandleCollectDHCPOptionSetsTask handles the task for collecting AWS DHCP option sets.
+func HandleCollectDHCPOptionSetsTask(ctx context.Context, t *asynq.Task) error {
+	// If we were called without a payload, then we enqueue tasks for
+	// collecting DHCP option sets for all known regions.
+	data := t.Payload()
+	if data == nil {
+		return enqueueCollectDHCPOptionSets(ctx)
+	}
+
+	var payload CollectDHCPOptionSetsPayload
+	if err := asynqutils.Unmarshal(data, &payload); err != nil {
+		return asynqutils.SkipRetry(err)
+	}
+
+	if payload.AccountID == "" {
+		return asynqutils.SkipRetry(ErrNoAccountID)
+	}
+
+	if payload.Region == "" {
+		return asynqutils.SkipRetry(ErrNoRegion)
+	}
+
+	return collectDHCPOptionSets(ctx, payload)
+}
+
+// enqueueCollectDHCPOptionSets enqueues tasks for collecting AWS DHCP option sets from all known
+// regions by creating payload with the respective region and account id.
+func enqueueCollectDHCPOptionSets(ctx context.Context) error {
+	regions, err := awsutils.GetRegionsFromDB(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get regions: %w", err)
+	}
+
+	logger := asynqutils.GetLogger(ctx)
+	queue := asynqutils.GetQueueName(ctx)
+
+	// Enqueue task for each region
+	for _, r := range regions {
+		if !awsclients.EC2Clientset.Exists(r.AccountID) {
+			logger.Warn(
+				"AWS client not found",
+				"region", r.Name,
+				"account_id", r.AccountID,
+			)
+
+			continue
+		}
+
+		payload := CollectDHCPOptionSetsPayload{
+			Region:    r.Name,
+			AccountID: r.AccountID,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			logger.Error(
+				"failed to marshal payload for AWS DHCP option set",
+				"region", r.Name,
+				"account_id", r.AccountID,
+				"reason", err,
+			)
+
+			continue
+		}
+
+		task := asynq.NewTask(TaskCollectDHCPOptionSets, data)
+		info, err := asynqclient.Client.Enqueue(task, asynq.Queue(queue))
+		if err != nil {
+			logger.Error(
+				"failed to enqueue task",
+				"type", task.Type(),
+				"region", r.Name,
+				"account_id", r.AccountID,
+				"reason", err,
+			)
+
+			continue
+		}
+
+		logger.Info(
+			"enqueued task",
+			"type", task.Type(),
+			"id", info.ID,
+			"queue", info.Queue,
+			"region", r.Name,
+			"account_id", r.AccountID,
+		)
+	}
+
+	return nil
+}
+
+// collectDHCPOptionSets collects the AWS DHCP option sets from the specified payload region using the
+// client associated with the specified AccountID.
+func collectDHCPOptionSets(ctx context.Context, payload CollectDHCPOptionSetsPayload) error {
+	client, ok := awsclients.EC2Clientset.Get(payload.AccountID)
+	if !ok {
+		return asynqutils.SkipRetry(ClientNotFound(payload.AccountID))
+	}
+
+	var count int64
+	defer func() {
+		metric := prometheus.MustNewConstMetric(
+			dhcpOptionSetDesc,
+			prometheus.GaugeValue,
+			float64(count),
+			payload.AccountID,
+			payload.Region,
+		)
+		key := metrics.Key(TaskCollectDHCPOptionSets, payload.AccountID, payload.Region)
+		metrics.DefaultCollector.AddMetric(key, metric)
+	}()
+
+	logger := asynqutils.GetLogger(ctx)
+	logger.Info(
+		"collecting AWS DHCP option sets",
+		"region", payload.Region,
+		"account_id", payload.AccountID,
+	)
+
+	paginator := ec2.NewDescribeDhcpOptionsPaginator(
+		client.Client,
+		&ec2.DescribeDhcpOptionsInput{},
+		func(params *ec2.DescribeDhcpOptionsPaginatorOptions) {
+			params.Limit = int32(constants.PageSize)
+			params.StopOnDuplicateToken = true
+		},
+	)
+
+	// Fetch items from all pages
+	items := make([]types.DhcpOptions, 0)
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(
+			ctx,
+			func(o *ec2.Options) {
+				o.Region = payload.Region
+			},
+		)
+
+		if err != nil {
+			logger.Error(
+				"could not describe DHCP option sets",
+				"region", payload.Region,
+				"account_id", payload.AccountID,
+				"reason", err,
+			)
+
+			return err
+		}
+		items = append(items, page.DhcpOptions...)
+	}
+
+	dhcpOptionSets := make([]models.DHCPOptionSet, 0, len(items))
+	for _, set := range items {
+		name := awsutils.FetchTag(set.Tags, "Name")
+
+		if set.DhcpOptionsId == nil {
+			logger.Warn(
+				"empty DHCP option set id",
+				"name", name,
+			)
+
+			continue
+		}
+
+		item := models.DHCPOptionSet{
+			Name:         name,
+			AccountID:    payload.AccountID,
+			SetID:        *set.DhcpOptionsId,
+			RegionName:   payload.Region,
+		}
+		dhcpOptionSets = append(dhcpOptionSets, item)
+	}
+
+	if len(dhcpOptionSets) == 0 {
+		return nil
+	}
+
+	out, err := db.DB.NewInsert().
+		Model(&dhcpOptionSets).
+		On("CONFLICT (set_id, account_id) DO UPDATE").
+		Set("name = EXCLUDED.name").
+		Set("region_name = EXCLUDED.region_name").
+		Set("updated_at = EXCLUDED.updated_at").
+		Returning("id").
+		Exec(ctx)
+
+	if err != nil {
+		logger.Error(
+			"could not insert DHCP option sets into db",
+			"region", payload.Region,
+			"account_id", payload.AccountID,
+			"reason", err,
+		)
+
+		return err
+	}
+
+	count, err = out.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	logger.Info(
+		"populated AWS DHCP option sets",
+		"region", payload.Region,
+		"account_id", payload.AccountID,
+		"count", count,
+	)
+
+	return nil
+}

--- a/pkg/aws/tasks/metrics.go
+++ b/pkg/aws/tasks/metrics.go
@@ -91,6 +91,15 @@ var (
 		[]string{"account_id", "region", "vpc_id"},
 		nil,
 	)
+
+	// dhcpOptionSetDesc is the descriptor for a metric, which tracks the
+	// number of collected AWS DHCP option sets.
+	dhcpOptionSetDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(metrics.Namespace, "", "aws_dhcp_option_set"),
+		"A gauge which tracks the number of collected AWS DHCP option sets",
+		[]string{"account_id", "region"},
+		nil,
+	)
 )
 
 // init registers the metrics with the [metrics.DefaultCollector]
@@ -105,5 +114,6 @@ func init() {
 		instancesDesc,
 		loadBalancersDesc,
 		netInterfacesDesc,
+		dhcpOptionSetDesc,
 	)
 }

--- a/pkg/aws/tasks/tasks.go
+++ b/pkg/aws/tasks/tasks.go
@@ -41,6 +41,7 @@ func HandleCollectAllTask(ctx context.Context, _ *asynq.Task) error {
 		NewCollectLoadBalancersTask,
 		NewCollectBucketsTask,
 		NewCollectNetworkInterfacesTask,
+		NewCollectDHCPOptionSetsTask,
 	}
 
 	return asynqutils.Enqueue(ctx, taskFns, asynq.Queue(queue))
@@ -80,6 +81,7 @@ func init() {
 	registry.TaskRegistry.MustRegister(TaskCollectLoadBalancers, asynq.HandlerFunc(HandleCollectLoadBalancersTask))
 	registry.TaskRegistry.MustRegister(TaskCollectBuckets, asynq.HandlerFunc(HandleCollectBucketsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectNetworkInterfaces, asynq.HandlerFunc(HandleCollectNetworkInterfacesTask))
+	registry.TaskRegistry.MustRegister(TaskCollectDHCPOptionSets, asynq.HandlerFunc(HandleCollectDHCPOptionSetsTask))
 	registry.TaskRegistry.MustRegister(TaskCollectAll, asynq.HandlerFunc(HandleCollectAllTask))
 	registry.TaskRegistry.MustRegister(TaskLinkAll, asynq.HandlerFunc(HandleLinkAllTask))
 }

--- a/pkg/aws/tasks/vpcs.go
+++ b/pkg/aws/tasks/vpcs.go
@@ -201,16 +201,16 @@ func collectVPCs(ctx context.Context, payload CollectVPCsPayload) error {
 	for _, vpc := range items {
 		name := awsutils.FetchTag(vpc.Tags, "Name")
 		item := models.VPC{
-			Name:         name,
-			AccountID:    payload.AccountID,
-			VpcID:        ptr.StringFromPointer(vpc.VpcId),
-			State:        string(vpc.State),
-			IPv4CIDR:     ptr.StringFromPointer(vpc.CidrBlock),
-			IPv6CIDR:     "", // TODO: fetch IPv6 CIDR
-			IsDefault:    ptr.Value(vpc.IsDefault, false),
-			OwnerID:      ptr.StringFromPointer(vpc.OwnerId),
+			Name:            name,
+			AccountID:       payload.AccountID,
+			VpcID:           ptr.StringFromPointer(vpc.VpcId),
+			State:           string(vpc.State),
+			IPv4CIDR:        ptr.StringFromPointer(vpc.CidrBlock),
+			IPv6CIDR:        "", // TODO: fetch IPv6 CIDR
+			IsDefault:       ptr.Value(vpc.IsDefault, false),
+			OwnerID:         ptr.StringFromPointer(vpc.OwnerId),
 			DHCPOptionSetID: ptr.StringFromPointer(vpc.DhcpOptionsId),
-			RegionName:   payload.Region,
+			RegionName:      payload.Region,
 		}
 		vpcs = append(vpcs, item)
 	}

--- a/pkg/aws/tasks/vpcs.go
+++ b/pkg/aws/tasks/vpcs.go
@@ -201,15 +201,16 @@ func collectVPCs(ctx context.Context, payload CollectVPCsPayload) error {
 	for _, vpc := range items {
 		name := awsutils.FetchTag(vpc.Tags, "Name")
 		item := models.VPC{
-			Name:       name,
-			AccountID:  payload.AccountID,
-			VpcID:      ptr.StringFromPointer(vpc.VpcId),
-			State:      string(vpc.State),
-			IPv4CIDR:   ptr.StringFromPointer(vpc.CidrBlock),
-			IPv6CIDR:   "", // TODO: fetch IPv6 CIDR
-			IsDefault:  ptr.Value(vpc.IsDefault, false),
-			OwnerID:    ptr.StringFromPointer(vpc.OwnerId),
-			RegionName: payload.Region,
+			Name:         name,
+			AccountID:    payload.AccountID,
+			VpcID:        ptr.StringFromPointer(vpc.VpcId),
+			State:        string(vpc.State),
+			IPv4CIDR:     ptr.StringFromPointer(vpc.CidrBlock),
+			IPv6CIDR:     "", // TODO: fetch IPv6 CIDR
+			IsDefault:    ptr.Value(vpc.IsDefault, false),
+			OwnerID:      ptr.StringFromPointer(vpc.OwnerId),
+			DHCPOptionSetID: ptr.StringFromPointer(vpc.DhcpOptionsId),
+			RegionName:   payload.Region,
 		}
 		vpcs = append(vpcs, item)
 	}
@@ -227,6 +228,7 @@ func collectVPCs(ctx context.Context, payload CollectVPCsPayload) error {
 		Set("ipv6_cidr = EXCLUDED.ipv6_cidr").
 		Set("is_default = EXCLUDED.is_default").
 		Set("owner_id = EXCLUDED.owner_id").
+		Set("dhcp_option_set_id = EXCLUDED.dhcp_option_set_id").
 		Set("region_name = EXCLUDED.region_name").
 		Set("updated_at = EXCLUDED.updated_at").
 		Returning("id").

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -238,8 +238,8 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 
 					// Enqueue task to collect pool members for this pool
 					memberPayload := CollectPoolMembersPayload{
-						Scope:    payload.Scope,
-						PoolID:   pool.ID,
+						Scope:  payload.Scope,
+						PoolID: pool.ID,
 					}
 					data, err := json.Marshal(memberPayload)
 					if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the following changes to AWS models:
- DHCPOptionSet model and collection task
- add column DHCPOptionSetID to VPC model ( to be able to link to the previous resource)
- migration file additions for above
- aws_orphan_dhcp_option_set view to filter on DHCP option sets with missing VPCs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not all DHCP option set information has been persisted. For example, tags and specific configurations, which are also dynamic (key-value strings) aren't collected, as they aren't needed for determining orphan resources. They can be added on a later iteration if needed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
AWS DHCP option set
```
