### PR TITLE
OpenStack volume attachments

### DIFF
--- a/internal/pkg/migrations/20250915080232_openstack_volume_attachment.tx.down.sql
+++ b/internal/pkg/migrations/20250915080232_openstack_volume_attachment.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "openstack_volume_attachment";

--- a/internal/pkg/migrations/20250915080232_openstack_volume_attachment.tx.up.sql
+++ b/internal/pkg/migrations/20250915080232_openstack_volume_attachment.tx.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "openstack_volume_attachment" (
+    "attachment_id" varchar NOT NULL,
+    "volume_id" varchar NOT NULL,
+    "attached_at" timestamptz NOT NULL,
+    "device" varchar NOT NULL,
+    "hostname" varchar NOT NULL,
+    "server_id" varchar NOT NULL,
+
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "l_openstack_volume_attachment_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "l_openstack_volume_attachment_key" UNIQUE ("attachment_id")
+);

--- a/pkg/openstack/models/models.go
+++ b/pkg/openstack/models/models.go
@@ -34,6 +34,7 @@ const (
 	ContainerModelName            = "openstack:model:container"
 	ObjectModelName               = "openstack:model:object"
 	VolumeModelName               = "openstack:model:volume"
+	VolumeAttachmentModelName     = "openstack:model:volume_attachment"
 
 	SubnetToNetworkModelName       = "openstack:model:link_subnet_to_network"
 	SubnetToProjectModelName       = "openstack:model:link_subnet_to_project"
@@ -65,6 +66,7 @@ var models = map[string]any{
 	ContainerModelName:            &Container{},
 	ObjectModelName:               &Object{},
 	VolumeModelName:               &Volume{},
+	VolumeAttachmentModelName:     &VolumeAttachment{},
 
 	// Link models
 	SubnetToNetworkModelName:       &SubnetToNetwork{},
@@ -431,6 +433,20 @@ type Volume struct {
 	Description       string    `bun:"description,notnull"`
 	TimeCreated       time.Time `bun:"volume_created_at,notnull"`
 	TimeUpdated       time.Time `bun:"volume_updated_at,notnull"`
+}
+
+// VolumeAttachment represents an OpenStack Volume attachment.
+// A single volume can have multiple attachments.
+type VolumeAttachment struct {
+	bun.BaseModel `bun:"table:openstack_volume_attachment"`
+	coremodels.Model
+
+	AttachmentID string    `bun:"attachment_id,notnull,unique:openstack_volume_attachment_key"`
+	VolumeID     string    `bun:"volume_id,notnull"`
+	AttachedAt   time.Time `bun:"attached_at,notnull"`
+	Device       string    `bun:"device,notnull"`
+	Hostname     string    `bun:"hostname,notnull"`
+	ServerID     string    `bun:"server_id,notnull"`
 }
 
 func init() {

--- a/pkg/openstack/tasks/pools.go
+++ b/pkg/openstack/tasks/pools.go
@@ -238,8 +238,8 @@ func collectPools(ctx context.Context, payload CollectPoolsPayload) error {
 
 					// Enqueue task to collect pool members for this pool
 					memberPayload := CollectPoolMembersPayload{
-						Scope:    payload.Scope,
-						PoolID:   pool.ID,
+						Scope:  payload.Scope,
+						PoolID: pool.ID,
 					}
 					data, err := json.Marshal(memberPayload)
 					if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the collection of volume attachments for OpenStack.
This is done in the same task as volumes, as it's extracted from the same object,
but collected in a separate model, because of the 1:n relationship.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
OpenStack volume attachments
```
