### PR TITLE
Gardener Cloud Profiles: deduplicate machine images

### DIFF
--- a/pkg/gardener/tasks/awsmachineimages.go
+++ b/pkg/gardener/tasks/awsmachineimages.go
@@ -157,11 +157,7 @@ func deduplicateAWSItemsByKey(items []models.CloudProfileAWSImage) []models.Clou
 	}
 
 	keyCompactFunc := func(a, b models.CloudProfileAWSImage) bool {
-		return strings.Compare(a.CloudProfileName, b.CloudProfileName) == 0 &&
-			strings.Compare(a.Name, b.Name) == 0 &&
-			strings.Compare(a.Version, b.Version) == 0 &&
-			strings.Compare(a.RegionName, b.RegionName) == 0 &&
-			strings.Compare(a.AMI, b.AMI) == 0
+		return keyCompareFunc(a, b) == 0
 	}
 
 	slices.SortFunc(items, keyCompareFunc)

--- a/pkg/gardener/tasks/azuremachineimages.go
+++ b/pkg/gardener/tasks/azuremachineimages.go
@@ -163,11 +163,7 @@ func deduplicateAzureItemsByKey(items []models.CloudProfileAzureImage) []models.
 	}
 
 	keyCompactFunc := func(a, b models.CloudProfileAzureImage) bool {
-		return strings.Compare(a.CloudProfileName, b.CloudProfileName) == 0 &&
-			strings.Compare(a.Name, b.Name) == 0 &&
-			strings.Compare(a.Version, b.Version) == 0 &&
-			strings.Compare(a.Architecture, b.Architecture) == 0 &&
-			strings.Compare(a.ImageID, b.ImageID) == 0
+		return keyCompareFunc(a, b) == 0
 	}
 
 	slices.SortFunc(items, keyCompareFunc)

--- a/pkg/gardener/tasks/gcpmachineimages.go
+++ b/pkg/gardener/tasks/gcpmachineimages.go
@@ -154,10 +154,7 @@ func deduplicateGCPItemsByKey(items []models.CloudProfileGCPImage) []models.Clou
 	}
 
 	keyCompactFunc := func(a, b models.CloudProfileGCPImage) bool {
-		return strings.Compare(a.CloudProfileName, b.CloudProfileName) == 0 &&
-			strings.Compare(a.Name, b.Name) == 0 &&
-			strings.Compare(a.Version, b.Version) == 0 &&
-			strings.Compare(a.Image, b.Image) == 0
+		return keyCompareFunc(a, b) == 0
 	}
 
 	slices.SortFunc(items, keyCompareFunc)

--- a/pkg/gardener/tasks/openstackmachineimages.go
+++ b/pkg/gardener/tasks/openstackmachineimages.go
@@ -156,11 +156,7 @@ func deduplicateOpenStackItemsByKey(items []models.CloudProfileOpenStackImage) [
 	}
 
 	keyCompactFunc := func(a, b models.CloudProfileOpenStackImage) bool {
-		return strings.Compare(a.CloudProfileName, b.CloudProfileName) == 0 &&
-			strings.Compare(a.Name, b.Name) == 0 &&
-			strings.Compare(a.Version, b.Version) == 0 &&
-			strings.Compare(a.RegionName, b.RegionName) == 0 &&
-			strings.Compare(a.ImageID, b.ImageID) == 0
+		return keyCompareFunc(a, b) == 0
 	}
 
 	slices.SortFunc(items, keyCompareFunc)


### PR DESCRIPTION
Add machine image key deduplication for azure/gcp/aws.

This is needed, as Cloud Profiles routinely duplicate machine image records, breaking our SQL insertion logic.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fix Gardener Cloud Profile collection
```
