### PR TITLE
github/workflows: clean go cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
       - name: Run linter
@@ -24,6 +25,10 @@ jobs:
         run: |
           set -eu
           make build
+      - name: Clean Go cache
+        run: |
+          set -eu
+          go clean -cache -modcache -testcache -fuzzcache
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build OCI image


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR cleans adds a step to clean up the Go cache before building the OCI image, as cache size has increased significantly with new versions of dependencies, which in some cases results in disk space being exhausted on the Github runner side.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
