### PR TITLE
Add an enable a middleware which wraps the configuration

### DIFF
--- a/cmd/inventory/utils.go
+++ b/cmd/inventory/utils.go
@@ -119,6 +119,7 @@ func newWorker(ctx context.Context, conf *config.Config) *workerutils.Worker {
 	// Configure middlewares
 	middlewares := []asynq.MiddlewareFunc{
 		asynqutils.NewLoggerMiddleware(slog.Default()),
+		asynqutils.NewConfigMiddleware(conf),
 		asynqutils.NewMeasuringMiddleware(),
 		asynqutils.NewMetricsMiddleware(),
 	}

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -289,6 +289,12 @@ aws:
   default_region: eu-central-1  # Frankfurt
   app_id: gardener-inventory  # Optional application specific identifier
 
+  # The list of excluded regions specifies AWS region names, from which
+  # collection will be skipped.
+  # excluded_regions:
+  #   - eu-west-1
+  #   - eu-west-2
+
   # This section provides configuration specific to each AWS service and which
   # named credentials are used for each service. This allows the Inventory to
   # connect to multiple AWS accounts based on the named credentials which are

--- a/pkg/aws/tasks/regions.go
+++ b/pkg/aws/tasks/regions.go
@@ -7,6 +7,7 @@ package tasks
 import (
 	"context"
 	"encoding/json"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/hibiken/asynq"
@@ -151,9 +152,17 @@ func collectRegions(ctx context.Context, payload CollectRegionsPayload) error {
 	}
 
 	regions := make([]models.Region, 0, len(result.Regions))
+	conf := asynqutils.GetConfig(ctx)
 	for _, region := range result.Regions {
+		regionName := ptr.StringFromPointer(region.RegionName)
+		if slices.Contains(conf.AWS.ExcludedRegions, regionName) {
+			logger.Warn("skipping excluded region", "region", regionName, "account_id", payload.AccountID)
+
+			continue
+		}
+
 		item := models.Region{
-			Name:        ptr.StringFromPointer(region.RegionName),
+			Name:        regionName,
 			AccountID:   payload.AccountID,
 			Endpoint:    ptr.StringFromPointer(region.Endpoint),
 			OptInStatus: ptr.StringFromPointer(region.OptInStatus),

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -532,6 +532,10 @@ type AWSConfig struct {
 	// AppID is an optional application specific identifier.
 	AppID string `yaml:"app_id"`
 
+	// ExcludedRegions is a list of AWS region names, which will be
+	// excluded from collection.
+	ExcludedRegions []string `yaml:"excluded_regions"`
+
 	// Services provides AWS service-specific configuration,
 	// e.g. credentials to use when accessing a given AWS service.
 	Services AWSServices `yaml:"services"`

--- a/pkg/utils/asynq/asynq.go
+++ b/pkg/utils/asynq/asynq.go
@@ -39,6 +39,9 @@ func Unmarshal(data []byte, v any) error {
 // loggerKey is the key used to store a [slog.Logger] in a [context.Context]
 type loggerKey struct{}
 
+// configKey is the key used to store a [config.Config] in a [context.Context]
+type configKey struct{}
+
 // GetLogger returns the [slog.Logger] instance from the provided context, if
 // found, or [slog.DefaultLogger] otherwise.
 func GetLogger(ctx context.Context) *slog.Logger {
@@ -49,6 +52,18 @@ func GetLogger(ctx context.Context) *slog.Logger {
 	}
 
 	return logger
+}
+
+// GetConfig returns the [config.Config] instance from the provided context, if
+// found, or an empty [config.Config] otherwise.
+func GetConfig(ctx context.Context) *config.Config {
+	value := ctx.Value(configKey{})
+	conf, ok := value.(*config.Config)
+	if !ok {
+		return &config.Config{}
+	}
+
+	return conf
 }
 
 // NewDefaultErrorHandler returns an [asynq.ErrorHandlerFunc], which logs the

--- a/pkg/utils/asynq/middlewares.go
+++ b/pkg/utils/asynq/middlewares.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hibiken/asynq"
 
+	"github.com/gardener/inventory/pkg/core/config"
 	"github.com/gardener/inventory/pkg/metrics"
 )
 
@@ -39,6 +40,22 @@ func NewLoggerMiddleware(logger *slog.Logger) asynq.MiddlewareFunc {
 			logHandler := logger.Handler().WithAttrs(attrs)
 			newLogger := slog.New(logHandler)
 			newCtx := context.WithValue(ctx, loggerKey{}, newLogger)
+
+			return handler.ProcessTask(newCtx, task)
+		}
+
+		return asynq.HandlerFunc(mw)
+	}
+
+	return asynq.MiddlewareFunc(middleware)
+}
+
+// NewConfigMiddleware returns a new [asynq.MiddlewareFunc], which embeds a
+// [config.Config] in the context provided to task handlers.
+func NewConfigMiddleware(conf *config.Config) asynq.MiddlewareFunc {
+	middleware := func(handler asynq.Handler) asynq.Handler {
+		mw := func(ctx context.Context, task *asynq.Task) error {
+			newCtx := context.WithValue(ctx, configKey{}, conf)
 
 			return handler.ProcessTask(newCtx, task)
 		}


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

This PR adds support for excluding specific AWS regions from being collected by specifying them in the `aws.excluded_regions` field.

It also introduces a new `asynq.Middleware`, which wraps the configuration, so that task handlers can refer to it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
aws: add support for excluding specific regions from being collected
```
